### PR TITLE
WIP: Podman provider

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -120,6 +120,15 @@ class AnsibleInventoryOutput:
         if password:
             host_info["ansible_password"] = password
 
+        if db_host.provider.name in ("docker", "podman"):
+            host_info.update(
+                {
+                    "ansible_host": db_host.id,
+                    "ansible_connection": db_host.provider.name,
+                    "ansible_user": "root",  # TODO make it configurable in provider
+                },
+            )
+
         if is_windows_host(meta_host):
             host_info.update(
                 {

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -33,27 +33,12 @@ from mrack.host import (
     STATUS_ERROR,
     STATUS_OTHER,
     STATUS_PROVISIONING,
-    Host,
 )
 from mrack.providers.provider import Provider
 
 logger = logging.getLogger(__name__)
 
 PROVISIONER_KEY = "beaker"
-
-STATUS_MAP = {
-    "Reserved": STATUS_ACTIVE,
-    "New": STATUS_PROVISIONING,
-    "Scheduled": STATUS_PROVISIONING,
-    "Queued": STATUS_PROVISIONING,
-    "Processed": STATUS_PROVISIONING,
-    "Waiting": STATUS_PROVISIONING,
-    "Installing": STATUS_PROVISIONING,
-    "Running": STATUS_PROVISIONING,
-    "Cancelled": STATUS_DELETED,
-    "Aborted": STATUS_ERROR,
-    "Completed": STATUS_OTHER,
-}
 
 
 class BeakerProvider(Provider):
@@ -65,6 +50,19 @@ class BeakerProvider(Provider):
         self.conf = PyConfigParser()
         self.poll_sleep = 30  # seconds
         self.keypair = None
+        self.STATUS_MAP = {
+            "Reserved": STATUS_ACTIVE,
+            "New": STATUS_PROVISIONING,
+            "Scheduled": STATUS_PROVISIONING,
+            "Queued": STATUS_PROVISIONING,
+            "Processed": STATUS_PROVISIONING,
+            "Waiting": STATUS_PROVISIONING,
+            "Installing": STATUS_PROVISIONING,
+            "Running": STATUS_PROVISIONING,
+            "Cancelled": STATUS_DELETED,
+            "Aborted": STATUS_ERROR,
+            "Completed": STATUS_OTHER,
+        }
 
     async def init(self, max_attempts, reserve_duration, keypair):
         """Initialize provider with data from Beaker configuration."""
@@ -87,6 +85,10 @@ class BeakerProvider(Provider):
         """Validate that host requirements are well specified."""
         return
 
+    async def can_provision(self, hosts):
+        """Checks that hosts can be provisioned."""
+        return True
+
     def _allow_ssh_key(self, ssh_key):
 
         with open(ssh_key, "r") as key_file:
@@ -104,6 +106,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         ]
 
     def _req_to_bkr_job(self, req):
+        """Transform requirement to beaker job xml"""
         specs = deepcopy(req)  # work with own copy, do not modify the input
 
         # Job attributes:
@@ -191,6 +194,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         return result
 
     def _get_recipe_info(self, beaker_id):
+        """Get info about the recipe for beaker job id."""
         bkr_job_xml = self.hub.taskactions.to_xml(beaker_id).encode("utf8")
 
         resources = []
@@ -234,11 +238,11 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
                 )
                 prev_status = status
 
-            if STATUS_MAP.get(status) == STATUS_ACTIVE:
+            if self.STATUS_MAP.get(status) == STATUS_ACTIVE:
                 break
-            elif STATUS_MAP.get(status) == STATUS_PROVISIONING:
+            elif self.STATUS_MAP.get(status) == STATUS_PROVISIONING:
                 await asyncio.sleep(self.poll_sleep)
-            elif STATUS_MAP.get(status) in [STATUS_ERROR, STATUS_DELETED]:
+            elif self.STATUS_MAP.get(status) in [STATUS_ERROR, STATUS_DELETED]:
                 logger.warning(
                     f"Job {beaker_id} has errored with status "
                     f"{status} with result {resource['result']}"
@@ -254,80 +258,13 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         resource.update({"JobID": beaker_id, "hname": req_hname})
         return resource
 
-    async def provision_hosts(self, hosts):
-        """Provision hosts based on list of host requirements.
-
-        Issues provisioning and waits for it succeed. Raises exception if any of
-        the servers was not successfully provisioned. If that happens it issues deletion
-        of all already provisioned resources.
-
-        Return list of information about provisioned servers.
-        """
-        started = datetime.now()
-
-        count = len(hosts)
-        logger.info(f"Issuing provisioning of {count} hosts")
-        create_res = []
-        for req in hosts:
-            resource = self.create_server(req)
-            create_res.append(resource)
-
-        create_resps = await asyncio.gather(*create_res)
-        logger.info("Provisioning issued")
-
-        logger.info("Waiting for all Beaker hosts to be available")
-        wait_res = []
-        for resp in create_resps:
-            resource = self.wait_till_provisioned(resp)
-            wait_res.append(resource)
-
-        server_results = await asyncio.gather(*wait_res)
-
-        provisioned = datetime.now()
-        provi_duration = provisioned - started
-
-        logger.info("All Beaker hosts reached provisioning final state (Reserved)")
-        logger.info(f"Provisioning duration: {provi_duration}")
-
-        hosts = [self.to_host(srv) for srv in server_results]
-        for host in hosts:
-            logger.info(host)
-
-        return hosts
-
     async def delete_host(self, host):
         """Delete provisioned hosts based on input from provision_hosts."""
         logger.info(f"Deleting Beaker host from Job {host.id}")
         return self.hub.taskactions.stop(
-            host.id, "cancel", "Job has been cancelled by mrack."
+            host.id, "cancel", "Job has been stopped by mrack."
         )
 
-    async def delete_hosts(self, hosts):
-        """Issue deletion of all servers based on previous results from provisioning."""
-        logger.info("Issuing Beaker deletion")
-
-        delete_bkr = []
-        for host in hosts:
-            awaitable = self.delete_host(host)
-            delete_bkr.append(awaitable)
-        results = await asyncio.gather(*delete_bkr)
-        logger.info("All Beaker servers issued to be deleted")
-
-        return results
-
-    def to_host(self, provisioning_result):
+    def to_host(self, provisioning_result, username=None):
         """Transform provisioning result into Host object."""
-        host_info = self._get_host_info_from_prov_result(provisioning_result)
-
-        host = Host(
-            self,
-            host_info.get("id"),
-            host_info.get("name"),
-            host_info.get("addresses"),
-            STATUS_MAP.get(host_info.get("status"), STATUS_OTHER),
-            provisioning_result,
-            username="root",
-            error_obj=host_info.get("fault"),
-        )
-
-        return host
+        return super().to_host(provisioning_result, username="root")

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -1,0 +1,140 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Podman provider module."""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+from mrack.errors import ProvisioningError, ServerNotFoundError
+from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_OTHER, Host
+from mrack.providers.provider import Provider
+from mrack.providers.utils.podman import Podman
+from mrack.utils import object2json
+
+logger = logging.getLogger(__name__)
+
+PROVISIONER_KEY = "podman"
+
+
+class PodmanProvider(Provider):
+    """Podman provisioning provider."""
+
+    def __init__(self):
+        """Initialize provider."""
+        self._name = PROVISIONER_KEY
+        self.podman = Podman()
+
+    async def validate_hosts(self, hosts):
+        """Validate that host requirements are well specified."""
+        return True  # TODO
+
+    async def can_provision(self, hosts):
+        """Check that provider has enough resources to provision hosts."""
+        return True  # TODO
+
+    async def create_server(self, req):
+        """Request and create resource on selected provider."""
+        hostname = req["name"]
+        logger.info(f"Creating container for host: {hostname}")
+        hostname = req["name"]
+        image = req["image"]
+        network = req.get("network")
+        container_id = await self.podman.run(image, hostname, network)
+        return container_id
+
+    async def wait_till_provisioned(self, resource):
+        """Wait till resource is provisioned."""
+        cont_id = resource
+
+        start = datetime.now()
+        timeout = 20
+        timeout_time = start + timedelta(minutes=timeout)
+
+        while datetime.now() < timeout_time:
+            try:
+                inspect = await self.podman.inspect(cont_id)
+            except ProvisioningError as e:
+                logger.error(object2json(e))
+                raise ServerNotFoundError(cont_id)
+            server = inspect[0]
+            running = server["State"]["Running"]
+            is_error = server["State"]["Error"]
+            # TODO: this should be changed after provider refactoring stops working
+            # with OpenStack based constants.
+            if running:
+                server["status"] = "ACTIVE"
+                break
+            if is_error:
+                server["status"] = "ERROR"
+                break
+
+            await asyncio.sleep(1)
+
+        done_time = datetime.now()
+        prov_duration = (done_time - start).total_seconds()
+
+        if datetime.now() >= timeout_time:
+            logger.warning(
+                f"{cont_id} was not provisioned within a timeout of" f" {timeout} mins"
+            )
+        else:
+            logger.info(f"{cont_id} was provisioned in {prov_duration:.1f}s")
+
+        logger.debug(object2json(server))
+        return server
+
+    async def delete_host(self, host):
+        """Delete provisioned host."""
+        uuid = host.id
+        deleted = await self.podman.rm(uuid, force=True)
+        return deleted
+
+    def get_status(self, state):
+        """Read status from inspect State object."""
+        if state.get("Running"):
+            return STATUS_ACTIVE
+        elif state.get("Dead"):
+            return STATUS_DELETED
+        elif state.get("Error"):
+            return STATUS_ERROR
+        else:
+            return STATUS_OTHER
+
+    def to_host(self, prov_result, username=None):
+        """Get needed host information from provisioning result."""
+        # prov_results is output of inspect method.
+
+        ip = None
+        network_set = prov_result.get("NetworkSettings")
+        if network_set:
+            ip = network_set.get("IPAddress")
+
+        status = self.get_status(prov_result.get("State"))
+        error_obj = None
+        if status == STATUS_ERROR:
+            error_obj = prov_result.get("State")
+
+        host = Host(
+            self,
+            prov_result.get("Id"),
+            prov_result["Config"]["Hostname"],
+            [ip],
+            status,
+            prov_result,
+            username=username,
+            error_obj=error_obj,
+        )
+        return host

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 """General Provider interface."""
+import asyncio
+import logging
+from datetime import datetime
+
+from mrack.errors import ProvisioningError, ValidationError
+from mrack.host import STATUS_OTHER, Host
 
 
 class Provider:
@@ -21,6 +27,7 @@ class Provider:
     def __init__(self, provisioning_config, job_config):
         """Initialize provider."""
         self._name = "dummy"
+        self.STATUS_MAP = {"OTHER": STATUS_OTHER}
         return
 
     @property
@@ -30,16 +37,116 @@ class Provider:
 
     async def validate_hosts(self, hosts):
         """Validate that host requirements are well specified."""
-        return
+        raise NotImplementedError()
 
     async def can_provision(self, hosts):
         """Check that provider has enough resources to provison hosts."""
         raise NotImplementedError()
 
-    async def provision_hosts(self, hosts):
-        """Provision hosts and wait for it to finish."""
+    async def create_server(self, req):
+        """Request and create resource on selected provider."""
         raise NotImplementedError()
 
-    async def delete_hosts(self, provisioning_results):
-        """Delete provisioned hosts based on input from provision_hosts."""
+    async def wait_till_provisioned(self, resource):
+        """Wait till resource is provisioned."""
         raise NotImplementedError()
+
+    async def provision_hosts(self, hosts, logger=None):
+        """Provision hosts based on list of host requirements.
+
+        Main provider method for provisioning.
+
+        First it validates that host requirements are valid and that
+        provider has enough resources(quota).
+
+        Then issues provisioning and waits for it succeed. Raises exception if any of
+        the servers was not successfully provisioned. If that happens it issues deletion
+        of all already provisioned resources.
+
+        Return list of information about provisioned servers.
+        """
+        if not logger:
+            logger = logging.getLogger(self.name)
+
+        logger.info("Validating hosts definitions")
+        await self.validate_hosts(hosts)
+        logger.info("Host definitions valid")
+
+        logger.info("Checking available resources")
+        can = await self.can_provision(hosts)
+        if not can:
+            raise ValidationError("Not enough resources to provision")
+        logger.info("Resource availability: OK")
+
+        started = datetime.now()
+
+        count = len(hosts)
+        logger.info(f"Issuing provisioning of {count} hosts")
+        create_servers = []
+        for req in hosts:
+            awaitable = self.create_server(req)
+            create_servers.append(awaitable)
+        create_resps = await asyncio.gather(*create_servers)
+        logger.info("Provisioning issued")
+
+        logger.info("Waiting for all hosts to be available")
+        wait_servers = []
+        for create_resp in create_resps:
+            awaitable = self.wait_till_provisioned(create_resp)
+            wait_servers.append(awaitable)
+
+        server_results = await asyncio.gather(*wait_servers)
+        provisioned = datetime.now()
+        provi_duration = provisioned - started
+
+        logger.info("All hosts reached provisioning final state (ACTIVE or ERROR)")
+        logger.info(f"Provisioning duration: {provi_duration}")
+
+        errors = [res for res in server_results if res["status"] == "ERROR"]
+        if errors:
+            logger.info("Some host did not start properly")
+            for err in errors:
+                self.print_basic_info(err)
+            logger.info("Given the error, will delete all hosts")
+            await self.delete_hosts(server_results, logger)
+            raise ProvisioningError(errors)
+
+        hosts = [self.to_host(srv) for srv in server_results]
+        for host in hosts:
+            logger.info(host)
+        return hosts
+
+    async def delete_host(self, host):
+        """Delete provisioned host."""
+        raise NotImplementedError()
+
+    async def delete_hosts(self, hosts, logger):
+        """Issue deletion of all servers based on previous results from provisioning."""
+        logger.info("Issuing deletion")
+        delete_servers = []
+        for host in hosts:
+            awaitable = self.delete_host(host)
+            delete_servers.append(awaitable)
+        results = await asyncio.gather(*delete_servers)
+        logger.info("All servers issued to be deleted")
+        return results
+
+    def _get_host_info_from_prov_result(self, prov_result):
+        """Get needed host infromation from AWS provisioning result."""
+        raise NotImplementedError()
+
+    def to_host(self, provisioning_result, username=None):
+        """Transform provisioning result into Host object."""
+        host_info = self._get_host_info_from_prov_result(provisioning_result)
+
+        host = Host(
+            self,
+            host_info.get("id"),
+            host_info.get("name"),
+            host_info.get("addresses"),
+            self.STATUS_MAP.get(host_info.get("status"), STATUS_OTHER),
+            provisioning_result,
+            username=username,
+            error_obj=host_info.get("fault"),
+        )
+        return host

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -17,6 +17,7 @@
 import asyncio
 import json
 import logging
+import subprocess
 from mrack.errors import ProvisioningError
 
 logger = logging.getLogger(__name__)
@@ -78,3 +79,8 @@ class Podman:
         args.append(container_id)
         stdout, stderr, process = await self._run_podman(args, raise_on_err=False)
         return process.returncode == 0
+
+    def interactive(self, container_id):
+        """Create interactive session."""
+        args = [self.program, "exec", "-ti", container_id, "bash"]
+        subprocess.run(args, text=True)

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -1,0 +1,80 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for working with podman."""
+
+import asyncio
+import json
+import logging
+from mrack.errors import ProvisioningError
+
+logger = logging.getLogger(__name__)
+
+
+class Podman:
+    """Async wrapper supporting most basic podman calls."""
+
+    def __init__(self, program="podman"):
+        """Init the instance."""
+        self.program = program
+
+    async def _run_podman(self, args, raise_on_err=True):
+        """Util method to execute podman process."""
+        process = await asyncio.create_subprocess_exec(
+            self.program,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        if stdout:
+            stdout = stdout.decode()
+        if stdout is None:
+            stdout = ""
+        if stderr:
+            stderr = stderr.decode()
+        if stdout is None:
+            stderr = ""
+        if process.returncode != 0 and raise_on_err:
+            raise ProvisioningError(stderr)
+        return stdout, stderr, process
+
+    async def run(self, image, hostname=None, network=None):
+        """Run a container."""
+        args = ["run", "-dti"]
+        if hostname:
+            args.extend(["-h", hostname])
+        if network:
+            args.extend(["--network", network])
+        args.append(image)
+
+        stdout, stderr, process = await self._run_podman(args)
+        container_id = stdout.strip()
+        return container_id
+
+    async def inspect(self, container_id):
+        """Inspects a container returns data loaded from JSON structure."""
+        args = ["inspect", container_id]
+        stdout, stderr, process = await self._run_podman(args)
+        inspect_data = json.loads(stdout)
+        return inspect_data
+
+    async def rm(self, container_id, force=False):
+        """Remove a container."""
+        args = ["rm"]
+        if force:
+            args.append("-f")
+        args.append(container_id)
+        stdout, stderr, process = await self._run_podman(args, raise_on_err=False)
+        return process.returncode == 0

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -36,6 +36,8 @@ from mrack.providers.beaker import PROVISIONER_KEY as BEAKER
 from mrack.providers.beaker import BeakerProvider
 from mrack.providers.openstack import PROVISIONER_KEY as OPENSTACK
 from mrack.providers.openstack import OpenStackProvider
+from mrack.providers.podman import PROVISIONER_KEY as PODMAN
+from mrack.providers.podman import PodmanProvider
 from mrack.providers.static import PROVISIONER_KEY as STATIC
 from mrack.providers.static import StaticProvider
 from mrack.utils import load_yaml, no_such_file_config_handler
@@ -59,6 +61,7 @@ def init_providers():
     providers.register(OPENSTACK, OpenStackProvider)
     providers.register(AWS, AWSProvider)
     providers.register(BEAKER, BeakerProvider)
+    providers.register(PODMAN, PodmanProvider)
     providers.register(STATIC, StaticProvider)
 
 

--- a/src/mrack/transformers/__init__.py
+++ b/src/mrack/transformers/__init__.py
@@ -25,6 +25,8 @@ from mrack.transformers.beaker import CONFIG_KEY as BEAKER_KEY
 from mrack.transformers.beaker import BeakerTransformer
 from mrack.transformers.openstack import CONFIG_KEY as OPENSTACK_KEY
 from mrack.transformers.openstack import OpenStackTransformer
+from mrack.transformers.podman import CONFIG_KEY as PODMAN_KEY
+from mrack.transformers.podman import PodmanTransformer
 from mrack.transformers.static import CONFIG_KEY as STATIC_KEY
 from mrack.transformers.static import StaticTransformer
 
@@ -65,4 +67,5 @@ transformers = Registry()
 transformers.register(OPENSTACK_KEY, OpenStackTransformer)
 transformers.register(AWS_KEY, AWSTransformer)
 transformers.register(BEAKER_KEY, BeakerTransformer)
+transformers.register(PODMAN_KEY, PodmanTransformer)
 transformers.register(STATIC_KEY, StaticTransformer)

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -33,13 +33,21 @@ class OpenStackTransformer(Transformer):
     async def init_provider(self):
         """Initialize associate provider."""
         images = self.config["images"].values()
-        await self._provider.init(image_names=images)
+        cnt = self._get_metadata_host_cnt()
+        await self._provider.init(image_names=images, host_cnt=cnt)
 
     def _get_flavor(self, host):
         """Get flavor by host group."""
         # TODO: add sizes
 
         return get_config_value(self.config["flavors"], host["group"])
+
+    def _get_metadata_host_cnt(self):
+        """Get all host count."""
+        res = 0
+        for domain in self._metadata.get("domains"):
+            res += len(domain.get("hosts"))  # will get all even from other provider
+        return res
 
     def _is_network_type(self, name):
         """Check if name is a configured network type in provisioning config."""

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Podman transformer module."""
+
+from mrack.transformers.transformer import Transformer
+from mrack.utils import get_config_value, print_obj
+
+CONFIG_KEY = "podman"
+
+
+class PodmanTransformer(Transformer):
+    """Podman transformer."""
+
+    _config_key = CONFIG_KEY
+    _required_config_attrs = [
+        "images",
+    ]
+
+    def _get_image(self, os):
+        """Get image name by OS name from provisioning config."""
+        return get_config_value(self.config["images"], os)
+
+    def create_host_requirement(self, host):
+        """Create single input for podman provisioner."""
+        return {
+            "name": host["name"],
+            "image": self._get_image(host["os"]),
+            "hostname": host["name"],
+        }
+
+    def create_host_requirements(self):
+        """Create inputs for all host for AWS provisioner."""
+        reqs = [self.create_host_requirement(host) for host in self.hosts]
+        print_obj(reqs)
+        return reqs


### PR DESCRIPTION
Add basic support for Podman.

So far supported:
* rootless containers
* Ansible via using "podman" connection in Inventory
* ssh action via attaching to the container

TODO:
* attach network the the containers
* privileged containers
* custom user mapping for provider as containers have different user than cloud images

I.e. test bench will be to install a FreeIPA server with couple replicas.

Commands usable for testing:
```
mrack -c $SOME_PATH/provisioning-config.yaml up -p podman $OTHER_PATH/simple_hosts.yaml 
mrack -c $SOME_PATH/provisioning-config.yaml destroy $OTHER_PATH/simple_hosts.yaml
mrack -c $SOME_PATH/provisioning-config.yaml ssh $OTHER_PATH/simple_hosts.yaml
mrack -c $SOME_PATH/provisioning-config.yaml list $OTHER_PATH/simple_hosts.yaml
ansible  -i mrack-inventory.yaml all  -m shell -a "cat /etc/redhat-release"
```

Example enhancement  of provisioning config:
```
podman:
    images:
        fedora-30: registry.fedoraproject.org/fedora:30
        fedora-31: registry.fedoraproject.org/fedora:31
        fedora-32: registry.fedoraproject.org/fedora:32
        fedora-latest: registry.fedoraproject.org/fedora:latest
        fedora-rawhide: registry.fedoraproject.org/fedora:rawhide
```

Example metadata file:
```
domains:
- hosts:
  - group: ipaserver
    name: f30.mrack.test
    os: fedora-30
    role: master
  - group: ipaserver
    name: f31.mrack.test
    os: fedora-31
    role: master
  - group: ipaserver
    name: f32.mrack.test
    os: fedora-32
    role: master
  - group: ipaserver
    name: rawhide.mrack.test
    os: fedora-rawhide
    role: master
  name: mrack.test
  type: test
```
