### PR TITLE
feat: basic part of podman provider

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -162,6 +162,15 @@ class AnsibleInventoryOutput:
         if password:
             host_info["ansible_password"] = password
 
+        if db_host.provider.name in ("docker", "podman"):
+            host_info.update(
+                {
+                    "ansible_host": db_host.id,
+                    "ansible_connection": db_host.provider.name,
+                    "ansible_user": "root",  # TODO make it configurable in provider
+                },
+            )
+
         if is_windows_host(meta_host):
             if "netbios" in meta_host:
                 host_info.update({"meta_netbios": meta_host["netbios"]})

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -1,0 +1,138 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Podman provider module."""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+from mrack.errors import ProvisioningError, ServerNotFoundError
+from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_OTHER, Host
+from mrack.providers.provider import Provider
+from mrack.providers.utils.podman import Podman
+from mrack.utils import object2json
+
+logger = logging.getLogger(__name__)
+
+PROVISIONER_KEY = "podman"
+
+
+class PodmanProvider(Provider):
+    """Podman provisioning provider."""
+
+    def __init__(self):
+        """Initialize provider."""
+        self._name = PROVISIONER_KEY
+        self.podman = Podman()
+
+    async def validate_hosts(self, hosts):
+        """Validate that host requirements are well specified."""
+        return True  # TODO
+
+    async def can_provision(self, hosts):
+        """Check that provider has enough resources to provision hosts."""
+        return True  # TODO
+
+    async def create_server(self, req):
+        """Request and create resource on selected provider."""
+        hostname = req["name"]
+        logger.info(f"Creating container for host: {hostname}")
+        hostname = req["name"]
+        image = req["image"]
+        network = req.get("network")
+        container_id = await self.podman.run(image, hostname, network)
+        return container_id
+
+    async def wait_till_provisioned(self, resource):
+        """Wait till resource is provisioned."""
+        cont_id = resource
+
+        start = datetime.now()
+        timeout = 20
+        timeout_time = start + timedelta(minutes=timeout)
+
+        while datetime.now() < timeout_time:
+            try:
+                inspect = await self.podman.inspect(cont_id)
+            except ProvisioningError as e:
+                logger.error(object2json(e))
+                raise ServerNotFoundError(cont_id)
+            server = inspect[0]
+            running = server["State"]["Running"]
+            is_error = server["State"]["Error"]
+            if running or is_error:
+                break
+            await asyncio.sleep(1)
+
+        done_time = datetime.now()
+        prov_duration = (done_time - start).total_seconds()
+
+        if datetime.now() >= timeout_time:
+            logger.warning(
+                f"{cont_id} was not provisioned within a timeout of" f" {timeout} mins"
+            )
+        else:
+            logger.info(f"{cont_id} was provisioned in {prov_duration:.1f}s")
+
+        logger.debug(object2json(server))
+        return server
+
+    def parse_errors(self, server_results):
+        """Parse provisioning errors from provider result."""
+        errors = [s for s in server_results if s["State"]["Error"]]
+        return errors
+
+    async def delete_host(self, host):
+        """Delete provisioned host."""
+        uuid = host.id
+        deleted = await self.podman.rm(uuid, force=True)
+        return deleted
+
+    def get_status(self, state):
+        """Read status from inspect State object."""
+        if state.get("Running"):
+            return STATUS_ACTIVE
+        elif state.get("Dead"):
+            return STATUS_DELETED
+        elif state.get("Error"):
+            return STATUS_ERROR
+        else:
+            return STATUS_OTHER
+
+    def to_host(self, prov_result, username=None):
+        """Get needed host information from provisioning result."""
+        # prov_results is output of inspect method.
+
+        ip = None
+        network_set = prov_result.get("NetworkSettings")
+        if network_set:
+            ip = network_set.get("IPAddress")
+
+        status = self.get_status(prov_result.get("State"))
+        error_obj = None
+        if status == STATUS_ERROR:
+            error_obj = prov_result.get("State")
+
+        host = Host(
+            self,
+            prov_result.get("Id"),
+            prov_result["Config"]["Hostname"],
+            [ip],
+            status,
+            prov_result,
+            username=username,
+            error_obj=error_obj,
+        )
+        return host

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -35,6 +35,7 @@ class PodmanProvider(Provider):
     def __init__(self):
         """Initialize provider."""
         self._name = PROVISIONER_KEY
+        self.dsp_name = "Podman"
         self.podman = Podman()
 
     async def validate_hosts(self, hosts):
@@ -89,15 +90,9 @@ class PodmanProvider(Provider):
         logger.debug(object2json(server))
         return server
 
-    def parse_errors(self, server_results):
-        """Parse provisioning errors from provider result."""
-        errors = [s for s in server_results if s["State"]["Error"]]
-        return errors
-
-    async def delete_host(self, host):
+    async def delete_host(self, host_id):
         """Delete provisioned host."""
-        uuid = host.id
-        deleted = await self.podman.rm(uuid, force=True)
+        deleted = await self.podman.rm(host_id, force=True)
         return deleted
 
     def get_status(self, state):

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -1,0 +1,80 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for working with podman."""
+
+import asyncio
+import json
+import logging
+from mrack.errors import ProvisioningError
+
+logger = logging.getLogger(__name__)
+
+
+class Podman:
+    """Async wrapper supporting most basic podman calls."""
+
+    def __init__(self, program="podman"):
+        """Init the instance."""
+        self.program = program
+
+    async def _run_podman(self, args, raise_on_err=True):
+        """Util method to execute podman process."""
+        process = await asyncio.create_subprocess_exec(
+            self.program,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        if stdout:
+            stdout = stdout.decode()
+        if stdout is None:
+            stdout = ""
+        if stderr:
+            stderr = stderr.decode()
+        if stdout is None:
+            stderr = ""
+        if process.returncode != 0 and raise_on_err:
+            raise ProvisioningError(stderr)
+        return stdout, stderr, process
+
+    async def run(self, image, hostname=None, network=None):
+        """Run a container."""
+        args = ["run", "-dti"]
+        if hostname:
+            args.extend(["-h", hostname])
+        if network:
+            args.extend(["--network", network])
+        args.append(image)
+
+        stdout, stderr, process = await self._run_podman(args)
+        container_id = stdout.strip()
+        return container_id
+
+    async def inspect(self, container_id):
+        """Inspects a container returns data loaded from JSON structure."""
+        args = ["inspect", container_id]
+        stdout, stderr, process = await self._run_podman(args)
+        inspect_data = json.loads(stdout)
+        return inspect_data
+
+    async def rm(self, container_id, force=False):
+        """Remove a container."""
+        args = ["rm"]
+        if force:
+            args.append("-f")
+        args.append(container_id)
+        stdout, stderr, process = await self._run_podman(args, raise_on_err=False)
+        return process.returncode == 0

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -17,6 +17,8 @@
 import asyncio
 import json
 import logging
+import subprocess
+
 from mrack.errors import ProvisioningError
 
 logger = logging.getLogger(__name__)
@@ -78,3 +80,8 @@ class Podman:
         args.append(container_id)
         stdout, stderr, process = await self._run_podman(args, raise_on_err=False)
         return process.returncode == 0
+
+    def interactive(self, container_id):
+        """Create interactive session."""
+        args = [self.program, "exec", "-ti", container_id, "bash"]
+        subprocess.run(args, text=True)

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -44,6 +44,8 @@ from mrack.providers.beaker import PROVISIONER_KEY as BEAKER
 from mrack.providers.beaker import BeakerProvider
 from mrack.providers.openstack import PROVISIONER_KEY as OPENSTACK
 from mrack.providers.openstack import OpenStackProvider
+from mrack.providers.podman import PROVISIONER_KEY as PODMAN
+from mrack.providers.podman import PodmanProvider
 from mrack.providers.static import PROVISIONER_KEY as STATIC
 from mrack.providers.static import StaticProvider
 from mrack.utils import load_yaml, no_such_file_config_handler
@@ -67,6 +69,7 @@ def init_providers():
     providers.register(OPENSTACK, OpenStackProvider)
     providers.register(AWS, AWSProvider)
     providers.register(BEAKER, BeakerProvider)
+    providers.register(PODMAN, PodmanProvider)
     providers.register(STATIC, StaticProvider)
 
 

--- a/src/mrack/transformers/__init__.py
+++ b/src/mrack/transformers/__init__.py
@@ -25,6 +25,8 @@ from mrack.transformers.beaker import CONFIG_KEY as BEAKER_KEY
 from mrack.transformers.beaker import BeakerTransformer
 from mrack.transformers.openstack import CONFIG_KEY as OPENSTACK_KEY
 from mrack.transformers.openstack import OpenStackTransformer
+from mrack.transformers.podman import CONFIG_KEY as PODMAN_KEY
+from mrack.transformers.podman import PodmanTransformer
 from mrack.transformers.static import CONFIG_KEY as STATIC_KEY
 from mrack.transformers.static import StaticTransformer
 
@@ -65,4 +67,5 @@ transformers = Registry()
 transformers.register(OPENSTACK_KEY, OpenStackTransformer)
 transformers.register(AWS_KEY, AWSTransformer)
 transformers.register(BEAKER_KEY, BeakerTransformer)
+transformers.register(PODMAN_KEY, PodmanTransformer)
 transformers.register(STATIC_KEY, StaticTransformer)

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Podman transformer module."""
+
+from mrack.transformers.transformer import Transformer
+from mrack.utils import get_config_value, print_obj
+
+CONFIG_KEY = "podman"
+
+
+class PodmanTransformer(Transformer):
+    """Podman transformer."""
+
+    _config_key = CONFIG_KEY
+    _required_config_attrs = [
+        "images",
+    ]
+
+    def _get_image(self, os):
+        """Get image name by OS name from provisioning config."""
+        return get_config_value(self.config["images"], os)
+
+    def create_host_requirement(self, host):
+        """Create single input for podman provisioner."""
+        return {
+            "name": host["name"],
+            "image": self._get_image(host["os"]),
+            "hostname": host["name"],
+        }
+
+    def create_host_requirements(self):
+        """Create inputs for all host for AWS provisioner."""
+        reqs = [self.create_host_requirement(host) for host in self.hosts]
+        print_obj(reqs)
+        return reqs


### PR DESCRIPTION
Add basic support for Podman.

So far supported:

    rootless containers
    Ansible via using "podman" connection in Inventory
    ssh action via attaching to the container

TODO:

    attach network the the containers
    privileged containers
    custom user mapping for provider as containers have different user than cloud images

I.e. test bench will be to install a FreeIPA server with couple replicas.

Commands usable for testing:

mrack -c $SOME_PATH/provisioning-config.yaml up -p podman $OTHER_PATH/simple_hosts.yaml 
mrack -c $SOME_PATH/provisioning-config.yaml destroy $OTHER_PATH/simple_hosts.yaml
mrack -c $SOME_PATH/provisioning-config.yaml ssh $OTHER_PATH/simple_hosts.yaml
mrack -c $SOME_PATH/provisioning-config.yaml list $OTHER_PATH/simple_hosts.yaml
ansible  -i mrack-inventory.yaml all  -m shell -a "cat /etc/redhat-release"

Example enhancement of provisioning config:

podman:
    images:
        fedora-30: registry.fedoraproject.org/fedora:30
        fedora-31: registry.fedoraproject.org/fedora:31
        fedora-32: registry.fedoraproject.org/fedora:32
        fedora-latest: registry.fedoraproject.org/fedora:latest
        fedora-rawhide: registry.fedoraproject.org/fedora:rawhide

Example metadata file:

domains:
- hosts:
  - group: ipaserver
    name: f30.mrack.test
    os: fedora-30
    role: master
  - group: ipaserver
    name: f31.mrack.test
    os: fedora-31
    role: master
  - group: ipaserver
    name: f32.mrack.test
    os: fedora-32
    role: master
  - group: ipaserver
    name: rawhide.mrack.test
    os: fedora-rawhide
    role: master
  name: mrack.test
  type: test
