### PR TITLE
Add mrack.conf which contains default enfironment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,138 @@
-# python
-*.pyc
-*.pyo
-*.swp
-__pycache__
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-# packaging folders
-/build/
-/dist/
-*.egg-info
+# C extensions
+*.so
 
-# editors
-.vscode
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
 
 # tox
 /.tox
 
 # sphinx
 docs/_build/
+
+# Editors
+/.vscode

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # -*- coding: utf-8 -*-
-
 from setuptools import setup, find_packages
 
 with open("README.md") as f:
@@ -21,6 +20,9 @@ with open("README.md") as f:
 
 with open("requirements.txt") as req:
     reqs = req.readlines()
+
+mrack_conf = "mrack.conf"
+prov_conf = "provisioning-config.yaml"
 
 setup(
     name="mrack",
@@ -37,4 +39,7 @@ setup(
     package_dir={"": "src"},
     install_requires=reqs,
     scripts=["scripts/mrack"],
+    package_data={
+        "mrack": [f"data/{datafile}" for datafile in [mrack_conf, prov_conf]]
+    },
 )

--- a/src/mrack/data/mrack.conf
+++ b/src/mrack/data/mrack.conf
@@ -1,0 +1,4 @@
+[mrack]
+mrackdb = .mrackdb.json
+provisioning-config = provisioning-config.yaml
+

--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -1,0 +1,82 @@
+aws: # aws provider config
+    images:
+        # list of ami images key is used in metadata ami image is used for provider e.g.
+        fedora-32: ami-0f1d60751946b66c5 # Fedora-Cloud-Base-32-1.6.x86_64-hvm-eu-central-1-gp2-0
+
+
+    flavors:
+        # list of available flavours to ask from provider  for vm specs
+        default: t2.nano # e.g. this is 1vcpus 0.5GB ram
+
+    keypair: mrack # this name points to uploaded and available in aws ec2 key configuration
+    security_group: sg-0ad1bab3a850e70fc # setup the system firewall using one of existing sec groups
+
+    credentials_file: aws.key # file containing the credentials
+    profile: default # credentials profile to use
+    region: eu-central-1 # default region for ec2 instances
+    instance_tags: # custom tag list to add to vm created using mrack
+        Name: "mrack-runner"
+        mrack: "True"
+        persistent: "False"
+
+
+beaker: # beaker provider specific values
+    distros:
+        # list of beaker distros key is used in metadata distro is used in generated jobxml
+        fedora-32: Fedora-32%
+
+    # path to public ssh key which is later uploaded to the machine for access
+    keypair: id_rsa.pub
+    # default reservation time for the beaker job
+    reserve_duration: 86400
+    # default max_attepmts value for the beaker job
+    max_attempts: 240
+
+
+openstack: # OpenStack provider specific values
+    images:
+        fedora-32: Fedora-Cloud-Base-32-latest
+
+    flavors:
+        # list of available flavours to ask from provider for vm specs
+        default: ci.m1.medium
+
+    networks: # networks supported by OpenStack instance
+        IPv4:
+        - provider_net_cci_4
+        IPv6:
+        - provider_net_ipv6_only
+
+    default_network: IPv4
+
+    # OpenStack vm config
+    keypair: jenkins
+
+    # OpenStack security/auth config
+    credentials_file: clouds.yaml
+    # credentials profile to use from file
+    profile: devstack
+
+# default user per image from the any of provider configuration
+users:
+    fedora-32: fedora
+    # fallback to default if not specified for distro
+    default: cloud-user
+
+# ansible_python_interpreter to use based on the distribution  / image
+python:
+    fedora-32: /usr/bin/python3
+    # fallback to default if not specified for distro
+    default: /usr/libexec/platform-python
+
+# Default values
+# For python pytest multihost - all will be copied
+mhcfg:
+    ssh_key_filename: 'config/id_rsa'
+    ad_admin_name: Administrator
+    ad_admin_password: Secret123
+    admin_name: admin
+    admin_password: Secret.123
+    dirman_dn: cn=Directory Manager
+    dirman_password: Secret.123
+    dns_forwarder: '8.8.8.8' # or any internal DNS

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -264,12 +264,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
                 )
                 break
 
-        resource.update(
-            {
-                "JobID": beaker_id,
-                "req_name": req_name,
-            }
-        )
+        resource.update({"JobID": beaker_id, "req_name": req_name})
         return resource
 
     async def delete_host(self, job_id):


### PR DESCRIPTION
Add mrack.conf from which we load defaults

Add mrack.conf which contains default enfironment
configuration in ini format for the click options
- `--config=provisioning-config from mrack.conf`
- `--db=mrackdb from mrack.conf`

Load default for options from the mrack.conf file from:
1. use `$(pwd)/mrack.conf` or other way the `./mrack.conf` - actual directory
2. or use user home directory configuration - `~/.mrack/mrack.conf`
3. alternatively directory `/etc/mrack/mrack.conf` as safe fallback.

Add example `mrack.conf` and `provisioning-config.yaml`
to the `data/` directory in repository.

Update setup.py to install required files from `data/` dir.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>
