### PR TITLE
Add basic image validation to AWS and Beaker

### DIFF
--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -55,6 +55,7 @@ class OpenStackProvider(Provider):
     def __init__(self):
         """Object initialization."""
         self._name = PROVISIONER_KEY
+        self.display_name = "OpenStack"
         self.flavors = {}
         self.flavors_by_ref = {}
         self.images = {}
@@ -83,7 +84,7 @@ class OpenStackProvider(Provider):
         * available flavors
         * networks
         * network availabilities (number of available IPs for networks)
-        * images which were defined in `image_names` option
+        * images which were defined in `images` option
         * account limits (max and current usage of vCPUs, memory, ...)
         """
         # session expects that credentials will be set via env variables
@@ -102,7 +103,7 @@ class OpenStackProvider(Provider):
         logger.info(f"Login duration {login_duration}")
 
         object_start = datetime.now()
-        flavors, images, limits, networks, ips = await asyncio.gather(
+        _, _, limits, _, _ = await asyncio.gather(
             self.load_flavors(),
             self.load_images(image_names),
             self.nova.limits.show(),


### PR DESCRIPTION
Added basic image validation to AWS and Beaker provider
When os was not known in provisioning config, null/None
was taken and set as required image even for Openstack.

Value of 'os' is passed to req when image is not in place.
Then the 'os' value is seen in ValidationError messages
even instead of None/null in Openstack, AWS and Beaker.

Support image/distro definition from metadata.
And flag it with meta_distro/meta_image when used.
    
For AWS check image availability with boto.
When image is not present raise ValidationError

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>