### PR TITLE
docs: set master doc to index

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,8 @@ author = "Petr Vobornik"
 # The full version, including alpha/beta/rc tags
 release = "0.2.0"
 
+# to work with ReadTheDocs which is using version < 2.0
+master_doc = 'index'
 
 # -- General configuration ---------------------------------------------------
 
@@ -46,7 +48,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "default"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
From sphinx doc:
```
master_doc

    The document name of the “master” document, that is, the document
    that contains the root toctree directive. Default is 'index'.

    Changed in version 2.0: The default is changed to 'index' from 'contents'.
```

Read the docs is using version < 2.0 thus it tries to find 'content's
and it fails.

Also changing theme to default - no real reason, thinking it will be
better.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>

Currently build fails with: 
`master file /home/docs/checkouts/readthedocs.org/user_builds/mrack/checkouts/latest/docs/contents.rst not found`