### PR TITLE
Remove missing and unused print_basic_info method

### DIFF
--- a/src/mrack/host.py
+++ b/src/mrack/host.py
@@ -142,6 +142,11 @@ class Host:
         return self._status
 
     @property
+    def error(self):
+        """Get host error object."""
+        return self._error
+
+    @property
     def username(self):
         """Get username for connecting to host."""
         return self._username

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -22,13 +22,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from mrack.errors import ProvisioningError, ValidationError
-from mrack.host import (
-    STATUS_ACTIVE,
-    STATUS_DELETED,
-    STATUS_ERROR,
-    STATUS_OTHER,
-    STATUS_PROVISIONING,
-)
+from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_PROVISIONING
 from mrack.providers.provider import Provider
 
 logger = logging.getLogger(__name__)
@@ -155,15 +149,6 @@ class AWSProvider(Provider):
 
         return result
 
-    def parse_errors(self, server_results):
-        """Parse provisioning errors from provider result."""
-        errors = []
-        for res in server_results:
-            if self.STATUS_MAP.get(res["State"]["Name"], STATUS_OTHER) == STATUS_ERROR:
-                errors.append(res)
-
-        return errors
-
     async def wait_till_provisioned(self, aws_id):
         """Wait for AWS provisioning result."""
         instance = self.ec2.Instance(aws_id)
@@ -179,10 +164,10 @@ class AWSProvider(Provider):
 
         return result
 
-    async def delete_host(self, host):
+    async def delete_host(self, host_id):
         """Delete provisioned hosts based on input from provision_hosts."""
-        logger.info(f"Terminating AWS host {host.id}")
-        ids = [host._id]
+        logger.info(f"Terminating AWS host {host_id}")
+        ids = [host_id]
         self.ec2.instances.filter(InstanceIds=ids).stop()
         self.ec2.instances.filter(InstanceIds=ids).terminate()
         return True

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -267,20 +267,11 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         resource.update({"JobID": beaker_id, "hname": req_hname})
         return resource
 
-    def parse_errors(self, server_results):
-        """Parse provisioning errors from provider result."""
-        errors = []
-        for res in server_results:
-            if self.STATUS_MAP.get(res["status"], STATUS_OTHER) == STATUS_ERROR:
-                errors.append(res)
-
-        return errors
-
-    async def delete_host(self, host):
+    async def delete_host(self, job_id):
         """Delete provisioned hosts based on input from provision_hosts."""
-        logger.info(f"Deleting Beaker host from Job {host.id}")
+        logger.info(f"Deleting Beaker host from Job {job_id}")
         return self.hub.taskactions.stop(
-            host.id, "cancel", "Job has been stopped by mrack."
+            job_id, "cancel", "Job has been stopped by mrack."
         )
 
     def to_host(self, provisioning_result, username=None):

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -369,15 +369,6 @@ class OpenStackProvider(Provider):
             logger.warning(f"Server '{uuid}' not found, probably already deleted")
             pass
 
-    def parse_errors(self, server_results):
-        """Parse provisioning errors from provider result."""
-        errors = []
-        for res in server_results:
-            if self.STATUS_MAP.get(res["status"], STATUS_OTHER) == STATUS_ERROR:
-                errors.append(res)
-
-        return errors
-
     async def wait_till_provisioned(
         self, instance, timeout=None, poll_sleep=None, poll_sleep_initial=None
     ):
@@ -434,10 +425,10 @@ class OpenStackProvider(Provider):
 
         return server
 
-    async def delete_host(self, host):
+    async def delete_host(self, host_id):
         """Issue deletion of host(server) from OpenStack."""
-        logger.info(f"Deleting OpenStack host {host.id}")
-        await self.delete_server(host._id)
+        logger.info(f"Deleting OpenStack host {host_id}")
+        await self.delete_server(host_id)
         return True
 
     def prov_result_to_host_data(self, prov_result):


### PR DESCRIPTION
Remove missing and unused print_basic_info method
    
    Add loger info message to error parsing method.
    Move the parse_errors to provider.py file.
    Add property error to Host object.
    Delete host now needs only host_id.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>