### PR TITLE
Support restraint_id record in metadata and fix destroy action

### DIFF
--- a/src/mrack/host.py
+++ b/src/mrack/host.py
@@ -158,6 +158,6 @@ class Host:
 
     async def delete(self):
         """Issue host deletion via associated provider."""
-        await self.provider.delete_host(self)
+        await self.provider.delete_host(self.id)
         self._status = STATUS_DELETED
         return True

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -141,6 +141,10 @@ class AnsibleInventoryOutput:
                 "DC=%s" % dc for dc in meta_domain["name"].split(".")
             ),
         }
+
+        if "restraint_id" in meta_host:
+            host_info.update({"meta_restraint_id": meta_host["restraint_id"]})
+
         copy_meta_attrs(host_info, meta_host, ["os", "role", "netbios"])
 
         if "parent" in meta_domain:

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -139,6 +139,7 @@ class AWSProvider(Provider):
             "status": None,
             "fault": None,
         }
+
         result["id"] = prov_result.get("InstanceId")
         for tag in prov_result.get("Tags"):
             if tag["Key"] == "name":

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -194,7 +194,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
 
         result = {
             "id": prov_result["JobID"],
-            "name": prov_result["hname"],
+            "name": prov_result["req_name"],
             "addresses": [ip_address],
             "status": prov_result["status"],
             "fault": prov_result["result"] if prov_result["result"] != "Pass" else None,
@@ -221,10 +221,10 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         return resources[0] if len(resources) == 1 else []
 
     async def wait_till_provisioned(
-        self, bkr_id_name, timeout=None, poll_sleep=None, max_attempts=None
+        self, bkr_id_req_name, timeout=None, poll_sleep=None, max_attempts=None
     ):
         """Wait for Beaker provisioning result."""
-        beaker_id, req_hname = bkr_id_name
+        beaker_id, req_name = bkr_id_req_name
 
         if not poll_sleep:
             poll_sleep = self.poll_sleep
@@ -264,7 +264,12 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
                 )
                 break
 
-        resource.update({"JobID": beaker_id, "hname": req_hname})
+        resource.update(
+            {
+                "JobID": beaker_id,
+                "req_name": req_name,
+            }
+        )
         return resource
 
     async def delete_host(self, job_id):

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -68,6 +68,7 @@ class AWSTransformer(Transformer):
             "flavor": self._get_flavor(host),
             "image": required_image,
             "meta_image": "image" in host,
+            "restraint_id": host.get("restraint_id"),
         }
 
     def create_host_requirements(self):

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -65,6 +65,7 @@ class BeakerTransformer(Transformer):
             "meta_distro": "distro" in host,
             "arch": host.get("arch", "x86_64"),
             "variant": self._get_variant(host),
+            "restraint_id": host.get("restraint_id"),
         }
 
     def create_host_requirements(self):

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -163,6 +163,7 @@ class OpenStackTransformer(Transformer):
             "meta_image": "image" in host,
             "key_name": self.config["keypair"],
             "network": self._get_network_type(host),
+            "restraint_id": host.get("restraint_id"),
         }
 
     def create_host_requirements(self):


### PR DESCRIPTION
Support restraint_id defined in metadata and later
defined in inventory for the restraint jobs.
For this we pass requirements all the way
for later inventory generation.

Before:
```yaml
#metadata 
domains:
- hosts:
  - group: ipaserver
    name: f32.mrack.test
    os: fedora-32
    role: master
  name: mrack.test

#mrack inventory
all:
  children:
    ipaserver:
      hosts:
        f32.mrack.test: {}
  hosts:
    f32.mrack.test:
       ansible_host: ec2.compute.amazonaws.com
      ansible_python_interpreter: /usr/bin/python3
      ansible_user: fedora
      meta_dc_record: DC=mrack,DC=test
      meta_domain: mrack.test
      meta_fqdn: f32.mrack.test
      meta_ip: 10.10.10.10
      meta_os: fedora-32
      meta_provider_id: i-0d92949afagag
      meta_role: master
```
After:
```yaml
#metadata 
domains:
- hosts:
  - group: ipaserver
    name: f32.mrack.test
    os: fedora-32
    role: master
    restraint_id: 9 # <<<<<<<<<<<<<<
  name: mrack.test

#mrack inventory
all:
  children:
    ipaserver:
      hosts:
        f32.mrack.test: {}
  hosts:
    f32.mrack.test:
      ansible_host: ec2.compute.amazonaws.com
      ansible_python_interpreter: /usr/bin/python3
      ansible_user: fedora
      meta_dc_record: DC=mrack,DC=test
      meta_domain: mrack.test
      meta_fqdn: f32.mrack.test
      meta_ip: 10.10.10.10
      meta_os: fedora-32
      meta_provider_id: i-0d92949afagag
      meta_restraint_id: 9  # <<<<<<<<<<<<<<
      meta_role: master
```

Fix destroy action because delete host now needs only host.id
    
    Because of delete_host method now needs only host.id,
    the Destroy action was broken and it needed to use
    the host.id variable not whole object as well.

before:
```
cannot pickle 'dict_values' object
Traceback (most recent call last):
...
```
after
```
Destroy done
```

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>