### PR TITLE
Require specific versions for mrack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-beaker-client>=27
-boto3
-click
-pyyaml
-asyncopenstackclient
+beaker-client==28
+botocore==1.18.18
+boto3==1.15.18
+click==7.1.2
+pyyaml==5.3.1
+asyncopenstackclient==0.8.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 black==20.8b1
-isort
-flake8
-pytest
-pydocstyle
-pytest-asyncio
+isort==5.6.4
+flake8==3.8.4
+pytest==6.1.2
+pytest-asyncio==0.14.0
+pydocstyle==5.1.1


### PR DESCRIPTION
It is always better to require specific versions
of dependencies because pip always installs
the latest and they may break funcionality
or create conflicts when mrack is a dependency.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>