### PR TITLE
Fix regression in up action with OpenStack provider

### DIFF
--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -160,10 +160,8 @@ class OpenStackTransformer(Transformer):
             "name": host["name"],
             "flavor": self._get_flavor(host),
             "image": required_image,
-            "meta_image": "image" in host,
             "key_name": self.config["keypair"],
             "network": self._get_network_type(host),
-            "restraint_id": host.get("restraint_id"),
         }
 
     def create_host_requirements(self):


### PR DESCRIPTION
Provisioning failed because requirements contained unexpected information.

I.e., the provider should receive only the information it expects or
are valid for OpenStack provisioning.

Removing the culprit lines: meta_image and restraint_id params.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>