### PR TITLE
Remove unused values in aws and beaker transformation

### DIFF
--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -68,7 +68,6 @@ class AWSTransformer(Transformer):
             "flavor": self._get_flavor(host),
             "image": required_image,
             "meta_image": "image" in host,
-            "restraint_id": host.get("restraint_id"),
         }
 
     def create_host_requirements(self):

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -65,7 +65,6 @@ class BeakerTransformer(Transformer):
             "meta_distro": "distro" in host,
             "arch": host.get("arch", "x86_64"),
             "variant": self._get_variant(host),
-            "restraint_id": host.get("restraint_id"),
         }
 
     def create_host_requirements(self):


### PR DESCRIPTION
These values are loaded from metadata when generating
inventory so they do not need to be passed to provider.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>