### PR TITLE
Do not set username for pytest multihost config

### DIFF
--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -118,7 +118,9 @@ class PytestMultihostOutput:
         # ssh_key_filename must be absolute as it can be used from a different
         # working directory, e.g. running tests from git repo
         ssh_key_filename = self._config.get("ssh_key_filename")
-        if ssh_key_filename and not ssh_key_filename.startswith("~"):
+
+        # Update with SSH key path only if not already defined in mhcfg
+        if ssh_key_filename and not mhcfg.get("ssh_key_filename"):
             mhcfg["ssh_key_filename"] = os.path.abspath(ssh_key_filename)
 
         return mhcfg

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -19,7 +19,7 @@ import os
 from copy import deepcopy
 
 from mrack.outputs.utils import resolve_hostname
-from mrack.utils import get_password, get_username, save_yaml
+from mrack.utils import get_password, save_yaml
 
 DEFAULT_MHCFG_PATH = "pytest-multihost.yaml"
 
@@ -85,12 +85,9 @@ class PytestMultihostOutput:
                     logger.error(f"Host {host['name']} not found in the database.")
                     continue
 
-                username = get_username(provisioned_host, host, self._config)
                 password = get_password(provisioned_host, host, self._config)
                 # pytest-multihost doesn't support different ssh_keys per host
 
-                if username:
-                    host["username"] = username
                 if password:
                     host["password"] = password
 


### PR DESCRIPTION
We have actually not used it at it cannot be assumed that
the user used for provisioning should be used for pytest-multihost.

E.g. a lot of tests rely on root - to be able to completely control
the remote machine. That cannot be done, e.g. with default cloud-user.

(Though it can often sudo to root)

Let's keep there the more simple configuration, where user is the
same for all host and is defined in provisioning config 'mhcfg' dir.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>