### PR TITLE
Fix ssh action and improve its error UX

### DIFF
--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -28,7 +28,6 @@ from mrack.host import (
     STATUS_ACTIVE,
     STATUS_DELETED,
     STATUS_ERROR,
-    STATUS_OTHER,
     STATUS_PROVISIONING,
 )
 from mrack.providers.provider import Provider
@@ -446,6 +445,6 @@ class OpenStackProvider(Provider):
         networks = prov_result.get("addresses", {})
         result["addresses"] = [ip.get("addr") for n in networks.values() for ip in n]
         result["fault"] = prov_result.get("fault")
-        result["status"] = self.STATUS_MAP.get(prov_result.get("status"), STATUS_OTHER)
+        result["status"] = prov_result.get("status")
 
         return result

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -28,7 +28,13 @@ from mrack.actions.ssh import SSH
 from mrack.actions.up import Up
 from mrack.config import ProvisioningConfig
 from mrack.dbdrivers.file import FileDBDriver
-from mrack.errors import ConfigError, MetadataError, ProviderError, ValidationError
+from mrack.errors import (
+    ApplicationError,
+    ConfigError,
+    MetadataError,
+    ProviderError,
+    ValidationError,
+)
 from mrack.providers import providers
 from mrack.providers.aws import PROVISIONER_KEY as AWS
 from mrack.providers.aws import AWSProvider
@@ -190,6 +196,7 @@ def exception_handler(func):
             MetadataError,
             ValidationError,
             ProviderError,
+            ApplicationError,
         ) as known_error:
             logger.error(known_error)
             sys.exit(1)


### PR DESCRIPTION
Fix OpenStack provisioning status translation
    
    It is not needed to use a STATUS_MAP for translation status in
    prov_result_to_host_data as it is done also in to_host of parent
    class. Double translation doesn't work and thus everything provisioned
    had incorrecly status : "other".
    
    This has then a negative effect on ssh actione where no host is reported
    as active.
    
    Signed-off-by: Petr Vobornik <pvoborni@redhat.com>

Do not show traceback on ApplicationError
    
    So that, e.g., on ssh action, when there are no active host, user
    will not get an exception ending with:
    
    ```
    raise ApplicationError("No active host available.")
    ```
    
    But only:
    ```
    No active host available.
    ```
    
    Which is more user friendly.
    
    Signed-off-by: Petr Vobornik <pvoborni@redhat.com>
