### PR TITLE
Support netbios in windows host definition for the inventory

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -157,6 +157,9 @@ class AnsibleInventoryOutput:
             host_info["ansible_password"] = password
 
         if is_windows_host(meta_host):
+            if "netbios" in meta_host:
+                host_info.update({"meta_netbios": meta_host["netbios"]})
+
             host_info.update(
                 {
                     "ansible_port": 5986,
@@ -165,6 +168,7 @@ class AnsibleInventoryOutput:
                     "meta_domain_level": meta_host.get("domain_level", "top"),
                 }
             )
+
         return host_info
 
     def create_inventory(self):


### PR DESCRIPTION
Support netbios in windows host definition for the inventory

```
$ cat metadata-fedora-win.yaml
domains:
- hosts:
  - group: ipaserver
    name: f32.mrack.test
    os: fedora-32
    role: master
  name: mrack.test
- hosts:
  - group: ad_root
    name: root-dc.ad.test
    os: win-2016
    role: ad
    netbios: ADTEST # <<< NEW SUPPORT
  name: ad.test
  type: AD

$ cat mrack-inventory.yaml
all:
  children:
    ad_root:
      hosts:
        root-dc.ad.test: {}
    ipaserver:
      hosts:
        r82.mrack.test: {}
  hosts:
    r82.mrack.test:
      ansible_host: 10.0.153.118
      ansible_python_interpreter: /usr/libexec/platform-python
      ansible_ssh_private_key_file: config/id_rsa
      ansible_user: cloud-user
      meta_dc_record: DC=mrack,DC=test
      meta_domain: mrack.test
      meta_fqdn: r82.mrack.test
      meta_ip: 10.0.153.118
      meta_os: fedora-32
      meta_provider_id: 3b7672fb-006c-4efc-b085-d1f8128cd99f
      meta_role: master
    root-dc.ad.test:
      ansible_connection: winrm
      ansible_host: 10.0.155.160
      ansible_password: Secret123
      ansible_port: 5986
      ansible_python_interpreter: /usr/libexec/platform-python
      ansible_ssh_private_key_file: config/id_rsa
      ansible_user: Administrator
      ansible_winrm_server_cert_validation: ignore
      meta_dc_record: DC=ad,DC=test
      meta_domain: ad.test
      meta_domain_level: top
      meta_fqdn: root-dc.ad.test
      meta_ip: 10.0.155.160
      meta_netbios: ADTEST # <<< NEW
      meta_os: win-2016
      meta_provider_id: bbc8cb17-df15-49ab-8ae4-5c142e1855ee
      meta_role: ad
```


Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>