### PR TITLE
MrackConfig: improve the approach to be object based and easy to extend 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,138 @@
-# python
-*.pyc
-*.pyo
-*.swp
-__pycache__
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-# packaging folders
-/build/
-/dist/
-*.egg-info
+# C extensions
+*.so
 
-# editors
-.vscode
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
 
 # tox
 /.tox
 
 # sphinx
 docs/_build/
+
+# Editors
+/.vscode

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # -*- coding: utf-8 -*-
-
 from setuptools import setup, find_packages
 
 with open("README.md") as f:
@@ -21,6 +20,9 @@ with open("README.md") as f:
 
 with open("requirements.txt") as req:
     reqs = req.readlines()
+
+mrack_conf = "mrack.conf"
+prov_conf = "provisioning-config.yaml"
 
 setup(
     name="mrack",
@@ -37,4 +39,7 @@ setup(
     package_dir={"": "src"},
     install_requires=reqs,
     scripts=["scripts/mrack"],
+    package_data={
+        "mrack": [f"data/{datafile}" for datafile in [mrack_conf, prov_conf]]
+    },
 )

--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -17,6 +17,14 @@
 Provisioning config is general project configuration shared between multiple jobs
 """
 
+import logging
+import os
+from configparser import ConfigParser, NoOptionError, ParsingError
+
+from mrack.errors import ConfigError
+
+logger = logging.getLogger(__name__)
+
 
 class ProvisioningConfig:
     """Represents loaded provisioning configuration."""
@@ -36,3 +44,84 @@ class ProvisioningConfig:
     def get(self, key, default=None):
         """Get method as in dict for raw config."""
         return self._raw.get(key, default)
+
+
+class MrackConfig:
+    """Configuration for mrack itself."""
+
+    def __init__(self, user_provided_path=None):
+        """Init Mrack Config."""
+        self._user_provided_path = user_provided_path
+        self.config_name = "mrack.conf"
+        self.section = "mrack"
+
+    def get_config_paths(self):
+        """Get possible mrack configuration file paths ordered by priority."""
+        cwd = os.path.abspath(".")
+        home = os.path.expanduser("~")
+        paths = [
+            f"{cwd}/{self.config_name}",
+            f"{home}/.mrack/{self.config_name}",
+            f"/etc/mrack/{self.config_name}",
+        ]
+        if self._user_provided_path:
+            paths.insert(0, self._user_provided_path)
+        return paths
+
+    def load(self):
+        """Load mrack configuration, first config file wins, rest is ignored."""
+        cfg_paths = self.get_config_paths()
+        self._parser = ConfigParser()
+        chosen = None
+        for cfg_path in cfg_paths:
+            if os.path.exists(cfg_path):
+                chosen = cfg_path
+                break
+
+        if not chosen:
+            logger.debug("No config file found.")
+            self._parser.read_dict({"mrack": {}})  # empty mrack section
+            return
+
+        try:
+            logger.debug(f"Loading config file: {chosen}.")
+            self._parser.read(chosen)
+        except ParsingError:
+            raise ConfigError(f"Invalid syntax in configuration file {chosen}.")
+
+        if not self._parser.has_section(self.section):
+            raise ConfigError(
+                f"Configuration file {chosen} doesn't have "
+                f"required section [{self.section}]."
+            )
+
+        return
+
+    def __getitem__(self, key):
+        """Get configuration value."""
+        try:
+            value = self._parser.get(self.section, key)
+            return value
+        except NoOptionError:
+            raise KeyError(f"Configuration file doesn't have key: {key}")
+
+    def get(self, key, default=None):
+        """Get configuration value."""
+        try:
+            value = self._parser.get(self.section, key)
+            logger.debug(f"Config key: {key}, value: {value}")
+            return value
+        except NoOptionError:
+            return default
+
+    def provisioning_config_path(self, default=None):
+        """Return configured provisioning config path."""
+        return self.get("provisioning-config", default)
+
+    def db_path(self, default=None):
+        """Return configured Mrack database path."""
+        return self.get("mrackdb", default)
+
+    def metadata_path(self, default=None):
+        """Return configured job metadata path."""
+        return self.get("metadata", default)

--- a/src/mrack/data/mrack.conf
+++ b/src/mrack/data/mrack.conf
@@ -1,4 +1,4 @@
 [mrack]
 mrackdb = .mrackdb.json
 provisioning-config = provisioning-config.yaml
-
+metadata = metadata.yaml

--- a/src/mrack/data/mrack.conf
+++ b/src/mrack/data/mrack.conf
@@ -1,0 +1,4 @@
+[mrack]
+mrackdb = .mrackdb.json
+provisioning-config = provisioning-config.yaml
+

--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -1,0 +1,82 @@
+aws: # aws provider config
+    images:
+        # list of ami images key is used in metadata ami image is used for provider e.g.
+        fedora-32: ami-0f1d60751946b66c5 # Fedora-Cloud-Base-32-1.6.x86_64-hvm-eu-central-1-gp2-0
+
+
+    flavors:
+        # list of available flavours to ask from provider  for vm specs
+        default: t2.nano # e.g. this is 1vcpus 0.5GB ram
+
+    keypair: mrack # this name points to uploaded and available in aws ec2 key configuration
+    security_group: sg-0ad1bab3a850e70fc # setup the system firewall using one of existing sec groups
+
+    credentials_file: aws.key # file containing the credentials
+    profile: default # credentials profile to use
+    region: eu-central-1 # default region for ec2 instances
+    instance_tags: # custom tag list to add to vm created using mrack
+        Name: "mrack-runner"
+        mrack: "True"
+        persistent: "False"
+
+
+beaker: # beaker provider specific values
+    distros:
+        # list of beaker distros key is used in metadata distro is used in generated jobxml
+        fedora-32: Fedora-32%
+
+    # path to public ssh key which is later uploaded to the machine for access
+    keypair: id_rsa.pub
+    # default reservation time for the beaker job
+    reserve_duration: 86400
+    # default max_attepmts value for the beaker job
+    max_attempts: 240
+
+
+openstack: # OpenStack provider specific values
+    images:
+        fedora-32: Fedora-Cloud-Base-32-latest
+
+    flavors:
+        # list of available flavours to ask from provider for vm specs
+        default: ci.m1.medium
+
+    networks: # networks supported by OpenStack instance
+        IPv4:
+        - provider_net_cci_4
+        IPv6:
+        - provider_net_ipv6_only
+
+    default_network: IPv4
+
+    # OpenStack vm config
+    keypair: jenkins
+
+    # OpenStack security/auth config
+    credentials_file: clouds.yaml
+    # credentials profile to use from file
+    profile: devstack
+
+# default user per image from the any of provider configuration
+users:
+    fedora-32: fedora
+    # fallback to default if not specified for distro
+    default: cloud-user
+
+# ansible_python_interpreter to use based on the distribution  / image
+python:
+    fedora-32: /usr/bin/python3
+    # fallback to default if not specified for distro
+    default: /usr/libexec/platform-python
+
+# Default values
+# For python pytest multihost - all will be copied
+mhcfg:
+    ssh_key_filename: 'config/id_rsa'
+    ad_admin_name: Administrator
+    ad_admin_password: Secret123
+    admin_name: admin
+    admin_password: Secret.123
+    dirman_dn: cn=Directory Manager
+    dirman_password: Secret.123
+    dns_forwarder: '8.8.8.8' # or any internal DNS

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -264,12 +264,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
                 )
                 break
 
-        resource.update(
-            {
-                "JobID": beaker_id,
-                "req_name": req_name,
-            }
-        )
+        resource.update({"JobID": beaker_id, "req_name": req_name})
         return resource
 
     async def delete_host(self, job_id):

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -24,12 +24,7 @@ from asyncopenstackclient import AuthPassword, GlanceClient
 from simple_rest_client.exceptions import NotFoundError
 
 from mrack.errors import ServerNotFoundError, ValidationError
-from mrack.host import (
-    STATUS_ACTIVE,
-    STATUS_DELETED,
-    STATUS_ERROR,
-    STATUS_PROVISIONING,
-)
+from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_PROVISIONING
 from mrack.providers.provider import Provider
 from mrack.providers.utils.osapi import ExtraNovaClient, NeutronClient
 
@@ -98,7 +93,7 @@ class OpenStackProvider(Provider):
         await asyncio.gather(
             self.nova.init_api(self.api_timeout),
             self.glance.init_api(self.api_timeout),
-            self.neutron.init_api(self.api_timeout)
+            self.neutron.init_api(self.api_timeout),
         )
         login_end = datetime.now()
         login_duration = login_end - login_start

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -18,7 +18,6 @@ import asyncio
 import logging
 import os
 import sys
-from configparser import ConfigParser, NoOptionError, NoSectionError, ParsingError
 from functools import update_wrapper
 
 import click
@@ -28,7 +27,7 @@ from mrack.actions.list import List
 from mrack.actions.output import Output
 from mrack.actions.ssh import SSH
 from mrack.actions.up import Up
-from mrack.config import ProvisioningConfig
+from mrack.config import MrackConfig, ProvisioningConfig
 from mrack.dbdrivers.file import FileDBDriver
 from mrack.errors import (
     ApplicationError,
@@ -49,53 +48,6 @@ from mrack.providers.static import StaticProvider
 from mrack.utils import load_yaml, no_such_file_config_handler
 
 logger = logging.getLogger(__name__)
-
-
-def load_mrack_config(paths):
-    """Locate mrack.conf file."""
-    configs = ConfigParser()
-    configs.read(paths)
-    return configs
-
-
-def get_file_path_from_config(target_key, mrack_config=None):
-    """Get file paths from the mrack config."""
-    if mrack_config:
-        config = load_mrack_config(mrack_config)
-        return config["mrack"][target_key]
-    else:
-        home = os.path.expanduser("~")
-        cfg_paths = [os.path.abspath("."), f"{home}/.mrack", "/etc/mrack"]
-        for cfg_path in cfg_paths:
-            try:
-                cfg_file = os.path.abspath(f"{cfg_path}/mrack.conf")
-
-                logger.debug(
-                    f"Loading '{target_key}' from {cfg_file} configuration file."
-                )
-                config = load_mrack_config(cfg_file)
-
-                cfg_val = config.get("mrack", target_key)
-
-                if cfg_val.startswith("~"):
-                    res = cfg_val.replace("~", home)
-                else:
-                    res = os.path.abspath(os.path.join(cfg_path, cfg_val))
-
-                logger.info(f"Using '{res}' from {cfg_file} configuration file.")
-                return res
-            except (KeyError, NoOptionError):
-                logger.debug(
-                    f"Can not locate '{target_key}' in {cfg_file} configuration file."
-                )
-            except NoSectionError:
-                logger.debug(
-                    f"Can not locate 'mrack' section in {cfg_file} configuration file."
-                )
-            except ParsingError:
-                logger.debugs(f"Invalid syntax in {cfg_file} configuration file.")
-
-        raise ConfigError("Can not start mrack without proper configuration")
 
 
 def async_run(f):
@@ -124,28 +76,36 @@ def init_db(path):
 
 
 @no_such_file_config_handler(error="Provisioning config file not found: {path}")
-def init_config(path):
+def init_prov_config(path):
     """Load and initialize provisioning configuration."""
     config_data = load_yaml(path)
     config = ProvisioningConfig(config_data)
     return config
 
 
-@no_such_file_config_handler(error="Job metadata file not found: {path}")
-def init_metadata(path):
+def init_metadata(ctx, user_defined_path):
     """Load and initialize job metadata."""
-    metadata_data = load_yaml(path)
+    config = ctx.obj[CONFIG]
+    meta_path = user_defined_path or config.metadata_path()
+    if not meta_path:
+        raise ConfigError("Job metadata file path not provided.")
+    if not os.path.exists(meta_path):
+        raise ConfigError(f"Job metadata file not found: {meta_path}")
+    metadata_data = load_yaml(meta_path)
+    ctx.obj[METADATA] = metadata_data
+
     return metadata_data
 
 
 DB = "db"
 CONFIG = "config"
+PROV_CONFIG = "provconfig"
 METADATA = "metadata"
 
 
 @click.group()
-@click.option("-m", "--mrack-config", type=click.Path(exists=True))
-@click.option("-c", "--provisioning-config", type=click.Path(exists=True))
+@click.option("-c", "--mrack-config", type=click.Path(exists=True))
+@click.option("-p", "--provisioning-config", type=click.Path(exists=True))
 @click.option("-d", "--db", type=click.Path(exists=True))
 @click.option("--debug", default=False, is_flag=True)
 @click.pass_context
@@ -154,23 +114,23 @@ def mrackcli(ctx, mrack_config, provisioning_config, db, debug):
     if debug:
         logging.getLogger("mrack").setLevel(logging.DEBUG)
 
-    mrack_files = {"provisioning-config": provisioning_config, "mrackdb": db}
-
-    for config_key in mrack_files:
-        if mrack_files[config_key] is None:
-            mrack_files[config_key] = get_file_path_from_config(
-                config_key, mrack_config=mrack_config
-            )
+    config = MrackConfig(mrack_config)
+    config.load()
+    db_path = db or config.db_path("./.mrackdb.json")
+    p_config_path = provisioning_config or config.provisioning_config_path(
+        "./provisioning-config.yaml"
+    )
 
     init_providers()
     ctx.ensure_object(dict)
-    ctx.obj[DB] = init_db(mrack_files["mrackdb"])
-    ctx.obj[CONFIG] = init_config(mrack_files["provisioning-config"])
+    ctx.obj[CONFIG] = config
+    ctx.obj[DB] = init_db(db_path)
+    ctx.obj[PROV_CONFIG] = init_prov_config(p_config_path)
 
 
 @mrackcli.command()
 @click.pass_context
-@click.argument("metadata")
+@click.option("-m", "--metadata", type=click.Path(exists=True))
 @click.option("-p", "--provider", default="openstack")
 @async_run
 async def up(ctx, metadata, provider):
@@ -178,37 +138,38 @@ async def up(ctx, metadata, provider):
 
     Based on provided job metadata file and provisioning configuration.
     """
-    ctx.obj[METADATA] = init_metadata(metadata)
+    init_metadata(ctx, metadata)
+
     up_action = Up()
-    await up_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], provider, ctx.obj[DB])
+    await up_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], provider, ctx.obj[DB])
     await up_action.provision()
 
     output_action = Output()
-    await output_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    await output_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     await output_action.generate_outputs()
 
 
 @mrackcli.command()
 @click.pass_context
-@click.argument("metadata")
+@click.option("-m", "--metadata", type=click.Path(exists=True))
 @async_run
 async def destroy(ctx, metadata):
     """Destroy provisioned hosts."""
-    ctx.obj[METADATA] = init_metadata(metadata)
+    init_metadata(ctx, metadata)
     destroy_action = Destroy()
-    await destroy_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    await destroy_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     await destroy_action.destroy()
 
 
 @mrackcli.command()
 @click.pass_context
-@click.argument("metadata")
+@click.option("-m", "--metadata", type=click.Path(exists=True))
 @async_run
 async def output(ctx, metadata):
     """Create outputs - such as Ansible inventory."""
-    ctx.obj[METADATA] = init_metadata(metadata)
+    init_metadata(ctx, metadata)
     output_action = Output()
-    await output_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    await output_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     await output_action.generate_outputs()
 
 
@@ -224,15 +185,14 @@ async def list(ctx):
 
 @mrackcli.command()
 @click.pass_context
-@click.argument("metadata", type=click.Path(exists=True))
 @click.argument("hostname", required=False)
+@click.option("-m", "--metadata", type=click.Path(exists=True))
 @async_run
-async def ssh(ctx, metadata, hostname):
+async def ssh(ctx, hostname, metadata):
     """SSH to host."""
-    ctx.obj[METADATA] = init_metadata(metadata)
-
+    init_metadata(ctx, metadata)
     ssh_action = SSH()
-    ssh_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    ssh_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     ssh_action.ssh(hostname)
 
 


### PR DESCRIPTION
base on PR: https://github.com/neoave/mrack/pull/36

This commit implements a MrackConfig which allows to define options
and arguments otherwise needed in a configuration file and thus
save people's time with writing them in CLI.

Config file looks like:
```
[mrack]
mrackdb = config/mrackdb.yaml
provisioning-config = config/provisioning-config.yaml
metadata = config/metadata.yaml
```

Where each value is optional and existance of the config is also
optional.

Mrack looks for the config on these locations:
- user provided path via -c or --mrack-config global option
- ./mrack.conf
- ~/.mrack/mrack.conf
- /etc/mrack/mrack.conf

It also changes CLI of commands:
- metadata is no longer an argument but an option: -m or --metadata
- provisioning config shortcut changes to global -p

With these changes it is possible to define a config file to allow
just typing:
```
$ mrack up
$ mrack list
$ mrack ssh
$ mrack output
$ mrack destroy
```

The MrackConfig class is also extensible for new use cases.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>
