### PR TITLE
Simple way to add hosts into /etc/hosts file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,8 @@ include_trailing_comma = true
 known_first_party = "mrack"
 line_length = 88
 multi_line_output = 3
+
+[tool.pytest.ini_options]
+markers = [
+    "etc_hosts: passes path for etc_hosts fixture",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ addopts = -r fEsxXw --showlocals
 junit_family = xunit2
 testpaths =
     tests
+markers =
+    etc_hosts: passes path for etc_hosts fixture

--- a/src/mrack/actions/etchosts.py
+++ b/src/mrack/actions/etchosts.py
@@ -1,0 +1,146 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Etc-Hosts actions."""
+
+import getpass
+import logging
+
+from mrack.errors import ApplicationError, ConfigError
+from mrack.host import STATUS_ACTIVE
+
+logger = logging.getLogger(__name__)
+
+MRACK_START = "# Managed by mrack - start\n"
+MRACK_END = "# Managed by mrack - end\n"
+
+
+class EtcHostsUpdater:
+    """Object to manipulate with /etc/hosts file."""
+
+    def __init__(self, path="/etc/hosts"):
+        """Init the updater."""
+        self.path = path
+        with open(self.path, "r") as f:
+            self.lines = f.readlines()
+
+        # Trigger validation
+        self._locate_mrack_section()
+
+    def _locate_mrack_section(self):
+        """Locate mrack managed section."""
+        start = -1
+        end = -1
+        mrack_lines = []
+        errors = []
+        for index, line in enumerate(self.lines):
+            if MRACK_START in line:
+                if start != -1:
+                    errors.append("Multiple start marks.")
+                start = index
+            if MRACK_END in line:
+                if end != -1:
+                    errors.append("Multiple end marks.")
+                end = index
+            if start != -1 and end == -1 and index > start:
+                mrack_lines.append([index, line])
+
+        # Check errors:
+        if start == -1 and end != -1:
+            errors.append("Doesn't have start mark.")
+        if start != -1 and end == -1:
+            errors.append("Doesn't have end mark.")
+        if end < start:
+            errors.append("End mark before start mark.")
+
+        if errors:
+            error = "/etc/hosts has broken mrack managed section and needs fixing:\n"
+            for err in errors:
+                error += f"   {err}\n"
+            raise ConfigError(error)
+
+        return (start, end, mrack_lines)
+
+    def add_hosts(self, hosts):
+        """Add lines for hosts."""
+        start, end, mrack_lines = self._locate_mrack_section()
+
+        if start == -1:
+            start = len(self.lines)
+            self.lines.append(MRACK_START)
+            end = start + 1
+            self.lines.append(MRACK_END)
+
+        for host in hosts:
+            new_line = f"{host.ip} {host.name}\n"
+            for mrack_line in mrack_lines:
+                idx, line = mrack_line
+                # update: /etc/hosts has already a line for the host
+                if host.name in line:
+                    self.lines[idx] = new_line
+                    mrack_line[1] = new_line
+                    break
+            else:
+                mrack_lines.append([end, new_line])
+                self.lines.insert(end, new_line)
+                end += 1
+
+    def clear(self):
+        """Remove mrack managed lines."""
+        start, end, mrack_lines = self._locate_mrack_section()
+        if start:
+            del self.lines[start : end + 1]
+
+    def save(self):
+        """Save changes into /etc/hosts."""
+        try:
+            with open(self.path, "w") as f:
+                f.writelines(self.lines)
+        except PermissionError:
+            name = getpass.getuser()
+            err = (
+                f"Error: Not enough permissions to write into file: {self.path}.\n\n"
+                "Consider running mrack as root for this command e.g. via sudo "
+                "or add yourself the necessary rights, e.g. by: \n"
+                f"  $ sudo setfacl -m {name}:rw {self.path}"
+            )
+            raise ApplicationError(err)
+
+
+class EtcHostsUpdate:
+    """Add active vms to /etc/hosts file."""
+
+    def __init__(self, db_driver):
+        """Initialize the /etc/hosts update action."""
+        self._db_driver = db_driver
+        self.updater = EtcHostsUpdater()
+
+    def update(self):
+        """Update /etc/hosts."""
+        logger.info("Adding hosts to /etc/hosts file")
+
+        hosts = [h for h in self._db_driver.hosts.values() if h.status == STATUS_ACTIVE]
+        self.updater.add_hosts(hosts)
+        self.updater.save()
+
+        logger.info("Done")
+
+    def clear(self):
+        """Clear mrack records in /etc/hosts."""
+        logger.info("Clearing mrack records in /etc/hosts.")
+
+        self.updater.clear()
+        self.updater.save()
+
+        logger.info("Done")

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -23,6 +23,7 @@ from functools import update_wrapper
 import click
 
 from mrack.actions.destroy import Destroy
+from mrack.actions.etchosts import EtcHostsUpdate
 from mrack.actions.list import List
 from mrack.actions.output import Output
 from mrack.actions.ssh import SSH
@@ -194,6 +195,29 @@ async def ssh(ctx, hostname, metadata):
     ssh_action = SSH()
     ssh_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     ssh_action.ssh(hostname)
+
+
+@mrackcli.group()
+async def eh():
+    """Commands to update /etc/hosts file."""
+
+
+@eh.command()
+@click.pass_context
+@async_run
+async def add(ctx):
+    """Add active hosts to /etc/hosts file."""
+    eh_action = EtcHostsUpdate(ctx.obj[DB])
+    eh_action.update()
+
+
+@eh.command()
+@click.pass_context
+@async_run
+async def clear(ctx):
+    """Remove all mrack hosts from /etc/hosts file."""
+    eh_action = EtcHostsUpdate(ctx.obj[DB])
+    eh_action.clear()
 
 
 def exception_handler(func):

--- a/tests/unit/data/etc/etc.hosts
+++ b/tests/unit/data/etc/etc.hosts
@@ -1,0 +1,2 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6

--- a/tests/unit/data/etc/hosts_missing_end
+++ b/tests/unit/data/etc/hosts_missing_end
@@ -1,0 +1,4 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+# Managed by mrack - start

--- a/tests/unit/data/etc/hosts_missing_start
+++ b/tests/unit/data/etc/hosts_missing_start
@@ -1,0 +1,4 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+# Managed by mrack - end

--- a/tests/unit/data/etc/hosts_multi_end
+++ b/tests/unit/data/etc/hosts_multi_end
@@ -1,0 +1,7 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+# Managed by mrack - start
+# Managed by mrack - end
+10.20.30.40 foo.example.test
+# Managed by mrack - end

--- a/tests/unit/data/etc/hosts_multi_start
+++ b/tests/unit/data/etc/hosts_multi_start
@@ -1,0 +1,7 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+# Managed by mrack - start
+# Managed by mrack - start
+10.20.30.40 foo.example.test
+# Managed by mrack - end

--- a/tests/unit/data/etc/hosts_order
+++ b/tests/unit/data/etc/hosts_order
@@ -1,0 +1,6 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+# Managed by mrack - end
+10.20.30.40 foo.example.test
+# Managed by mrack - start

--- a/tests/unit/test_etchosts.py
+++ b/tests/unit/test_etchosts.py
@@ -1,0 +1,146 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+from unit.utils import copy_as_temp
+
+from mrack.actions.etchosts import EtcHostsUpdater
+from mrack.errors import ConfigError
+from mrack.host import Host
+
+
+def create_host(name, ip):
+    return Host(None, None, name, [ip], None, None)
+
+
+def hosts_data():
+    return [
+        create_host("host1.example.test", "192.168.125.20"),
+        create_host("host2.example.test", "192.168.125.21"),
+        create_host("host3.example.test", "192.168.125.22"),
+    ]
+
+
+@pytest.fixture
+def etc_hosts(request):
+    marker = request.node.get_closest_marker("etc_hosts")
+    print(marker.args[0])
+    test_path = copy_as_temp(marker.args[0])
+    yield test_path
+    os.remove(test_path)
+
+
+START_MARK = "# Managed by mrack - start\n"
+END_MARK = "# Managed by mrack - end\n"
+
+
+class TestEtcHostsUpdater:
+    def assert_updater_state(self, updater, hosts):
+        # expected added data
+        record1 = f"{hosts[0].ip} {hosts[0].name}\n"
+        record2 = f"{hosts[1].ip} {hosts[1].name}\n"
+        record3 = f"{hosts[2].ip} {hosts[2].name}\n"
+        lines = updater.lines
+
+        assert len(updater.lines) == 2 + 5, "expecting 5 new lines"
+
+        # lines contains
+        assert START_MARK in lines
+        assert END_MARK in lines
+        start_pos = lines.index(START_MARK)
+        end_pos = lines.index(END_MARK)
+        assert start_pos < end_pos
+
+        # records are present
+        assert record1 in lines
+        assert record2 in lines
+        assert record3 in lines
+
+        rec1_pos = lines.index(record1)
+        rec2_pos = lines.index(record2)
+        rec3_pos = lines.index(record3)
+
+        # records are between marks
+        assert rec1_pos > start_pos and rec1_pos < end_pos
+        assert rec2_pos > start_pos and rec2_pos < end_pos
+        assert rec3_pos > start_pos and rec3_pos < end_pos
+
+    def assert_cleanup(self, updater):
+        lines = updater.lines
+        assert len(updater.lines) == 2
+        assert START_MARK not in lines
+        assert END_MARK not in lines
+
+    @pytest.mark.etc_hosts("data/etc/etc.hosts")
+    def test_expected_functionality(self, etc_hosts):
+        updater = EtcHostsUpdater(etc_hosts)
+
+        # test initial read
+        assert len(updater.lines) == 2
+        assert updater.lines[0].startswith("127.0.0.1")
+        assert updater.lines[1].startswith("::1")
+
+        hosts = hosts_data()
+        updater.add_hosts(hosts)
+        self.assert_updater_state(updater, hosts)
+
+        # Running multiple times should result in the same state
+        updater.add_hosts(hosts)
+        self.assert_updater_state(updater, hosts)
+
+        # save the changes to file
+        updater.save()
+
+        # load the file again and check if the saved value are there
+        updater2 = EtcHostsUpdater(etc_hosts)
+        self.assert_updater_state(updater2, hosts)
+
+        # remove the added lines
+        updater2.clear()
+        self.assert_cleanup(updater2)
+        updater2.save()
+
+        updater3 = EtcHostsUpdater(etc_hosts)
+        self.assert_cleanup(updater3)
+
+    def test_default_path(self):
+        updater = EtcHostsUpdater()
+        assert updater.path == "/etc/hosts"
+
+    @pytest.mark.etc_hosts("data/etc/hosts_missing_start")
+    def test_invalid_missing_start(self, etc_hosts):
+        with pytest.raises(ConfigError, match=r"Doesn't have start mark."):
+            EtcHostsUpdater(etc_hosts)
+
+    @pytest.mark.etc_hosts("data/etc/hosts_missing_end")
+    def test_invalid_missing_end(self, etc_hosts):
+        with pytest.raises(ConfigError, match=r"Doesn't have end mark."):
+            EtcHostsUpdater(etc_hosts)
+
+    @pytest.mark.etc_hosts("data/etc/hosts_multi_start")
+    def test_invalid_multi_start(self, etc_hosts):
+        with pytest.raises(ConfigError, match=r"Multiple start marks."):
+            EtcHostsUpdater(etc_hosts)
+
+    @pytest.mark.etc_hosts("data/etc/hosts_multi_end")
+    def test_invalid_multi_end(self, etc_hosts):
+        with pytest.raises(ConfigError, match=r"Multiple end marks."):
+            EtcHostsUpdater(etc_hosts)
+
+    @pytest.mark.etc_hosts("data/etc/hosts_order")
+    def test_invalid_order(self, etc_hosts):
+        with pytest.raises(ConfigError, match=r"End mark before start mark."):
+            EtcHostsUpdater(etc_hosts)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,5 +1,7 @@
 import json
 import os
+import shutil
+import tempfile
 
 
 def test_dir_path():
@@ -11,3 +13,13 @@ def get_data(name, data_dir="data"):
     with open(path, "r") as file_data:
         data = json.load(file_data)
     return data
+
+
+def copy_as_temp(data_path, text=True):
+    """
+    Makes a temporary copy of file relative to test dir and return it file path.
+    """
+    source_path = os.path.join(test_dir_path(), data_path)
+    temp_fp, temp_path = tempfile.mkstemp(text=text)
+    shutil.copy(source_path, temp_path)
+    return temp_path


### PR DESCRIPTION
This is useful for cases where the fake hostname needs to be used
e.g. when accessing FreeIPA Web UI which is sensitive on used hostname.

It is uncomfortable task to read the values from `mrack list` and add
them manualy to /etc/hosts.

The change introduces two commands to help with this case:

* `$ mrack eh add` to add all active hosts into /etc/hosts
* `$ mrack eh clear` to remove all records added by mrack.

Mrack adds two markers into the /etc/hosts file and adds records
between them. This should work also with multiple runs of mrack in
separate tests. If the section already contains the fake hostname then
this line is overwritten with a new value. This is useful when
provisioning hosts for the same task after they were previously
removed.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>