### PR TITLE
feat: Output file paths configurable in mrack config

### DIFF
--- a/src/mrack/actions/output.py
+++ b/src/mrack/actions/output.py
@@ -29,11 +29,15 @@ class Output:
     Test action to run output modules from data in database.
     """
 
-    async def init(self, config, metadata, db_driver):
+    async def init(
+        self, config, metadata, db_driver, ansible_path, pytest_multihost_path
+    ):
         """Initialize the Output action."""
         self._config = config
         self._metadata = metadata
         self._db_driver = db_driver
+        self._ansible_path = ansible_path
+        self._pytest_multihost_path = pytest_multihost_path
 
     async def generate_outputs(self):
         """Generate outputs."""
@@ -43,10 +47,10 @@ class Output:
             raise MetadataError("No hosts found.")
 
         ansible_o = AnsibleInventoryOutput(
-            self._config, self._db_driver, self._metadata
+            self._config, self._db_driver, self._metadata, self._ansible_path
         )
         multihost_o = PytestMultihostOutput(
-            self._config, self._db_driver, self._metadata
+            self._config, self._db_driver, self._metadata, self._pytest_multihost_path
         )
 
         ansible_o.create_output()

--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -125,3 +125,11 @@ class MrackConfig:
     def metadata_path(self, default=None):
         """Return configured job metadata path."""
         return self.get("metadata", default)
+
+    def ansible_inventory_path(self, default=None):
+        """Return configured path to Ansible inventory output."""
+        return self.get("ansible-inventory", default)
+
+    def pytest_multihost_path(self, default=None):
+        """Return configured path to pytest-multihost configuration output."""
+        return self.get("pytest-multihost", default)

--- a/src/mrack/data/mrack.conf
+++ b/src/mrack/data/mrack.conf
@@ -2,3 +2,5 @@
 mrackdb = .mrackdb.json
 provisioning-config = provisioning-config.yaml
 metadata = metadata.yaml
+ansible-inventory = mrack-inventory.yaml
+pytest-multihost = pytest-multihost.yaml

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Ansible inventory output module."""
+import logging
 import typing
 from copy import deepcopy
 
@@ -31,6 +32,8 @@ DEFAULT_INVENTORY_PATH = "mrack-inventory.yaml"
 DEFAULT_INVENTORY_LAYOUT: typing.Dict[str, typing.Dict] = {
     "all": {"children": {}, "hosts": {}}
 }
+
+logger = logging.getLogger(__name__)
 
 
 def copy_meta_attrs(host, meta_host, attrs):
@@ -106,12 +109,12 @@ class AnsibleInventoryOutput:
     files and information in DB.
     """
 
-    def __init__(self, config, db, metadata, path=DEFAULT_INVENTORY_PATH):
+    def __init__(self, config, db, metadata, path=None):
         """Init the output module."""
         self._config = config
         self._db = db
         self._metadata = metadata
-        self._path = path
+        self._path = path or DEFAULT_INVENTORY_PATH
 
     def create_ansible_host(self, name):
         """Create host entry for Ansible inventory."""
@@ -206,4 +209,6 @@ class AnsibleInventoryOutput:
         """Create the target output file."""
         inventory = self.create_inventory()
         save_yaml(self._path, inventory)
+        if self._path:
+            logger.info(f"Created: {self._path}")
         return inventory

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -36,12 +36,12 @@ class PytestMultihostOutput:
     metadata definition.
     """
 
-    def __init__(self, config, db, metadata, path=DEFAULT_MHCFG_PATH):
+    def __init__(self, config, db, metadata, path=None):
         """Init the output module."""
         self._config = config
         self._db = db
         self._metadata = metadata
-        self._path = path
+        self._path = path or DEFAULT_MHCFG_PATH
 
     def create_multihost_config(self):
         """
@@ -127,5 +127,8 @@ class PytestMultihostOutput:
 
     def create_output(self):
         """Create the target output file."""
-        inventory = self.create_multihost_config()
-        save_yaml(self._path, inventory)
+        mhcfg = self.create_multihost_config()
+        save_yaml(self._path, mhcfg)
+        if self._path:
+            logger.info(f"Created: {self._path}")
+        return mhcfg

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -98,6 +98,20 @@ def init_metadata(ctx, user_defined_path):
     return metadata_data
 
 
+async def generate_outputs(ctx):
+    """Init and run output action."""
+    config = ctx.obj[CONFIG]
+    output_action = Output()
+    await output_action.init(
+        ctx.obj[PROV_CONFIG],
+        ctx.obj[METADATA],
+        ctx.obj[DB],
+        config.ansible_inventory_path(),
+        config.pytest_multihost_path(),
+    )
+    await output_action.generate_outputs()
+
+
 DB = "db"
 CONFIG = "config"
 PROV_CONFIG = "provconfig"
@@ -145,9 +159,7 @@ async def up(ctx, metadata, provider):
     await up_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], provider, ctx.obj[DB])
     await up_action.provision()
 
-    output_action = Output()
-    await output_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
-    await output_action.generate_outputs()
+    await generate_outputs(ctx)
 
 
 @mrackcli.command()
@@ -169,9 +181,7 @@ async def destroy(ctx, metadata):
 async def output(ctx, metadata):
     """Create outputs - such as Ansible inventory."""
     init_metadata(ctx, metadata)
-    output_action = Output()
-    await output_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
-    await output_action.generate_outputs()
+    await generate_outputs(ctx)
 
 
 @mrackcli.command()

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -68,6 +68,8 @@ class TestStaticProvider:
             config=provisioning_config,
             metadata=metadata,
             db_driver=database,
+            ansible_path=None,
+            pytest_multihost_path=None,
         )
         await output_action.generate_outputs()
 


### PR DESCRIPTION
Adding a possibility to change Ansible inventory and pytest multihost
configuration output file paths in a mrack config file. So that user
can use directly a custom location.

Example of such config:

```ini
[mrack]
mrackdb = config/mrackdb.json
provisioning-config = config/provisioning-config.yaml
metadata = config/metadata.yaml
ansible-inventory = config/test.inventory.yaml
pytest-multihost = config/pytest-multihost-config.yaml
```

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>