### PR TITLE
fix: Use meta_ prefix for parent domain

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -150,7 +150,7 @@ class AnsibleInventoryOutput:
         copy_meta_attrs(host_info, meta_host, ["os", "role", "netbios"])
 
         if "parent" in meta_domain:
-            host_info["parent_domain"] = meta_domain["parent"]
+            host_info["meta_parent_domain"] = meta_domain["parent"]
 
         if ssh_key:
             host_info["ansible_ssh_private_key_file"] = ssh_key


### PR DESCRIPTION
When inventory was created the expected key value
for the parent_domain in host section should be
meta_parent_domain playbook will not fail with:
The error was: 'meta_parent_domain' is undefined

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>