### PR TITLE
chore: Add release workflow to github actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: 3.9
       - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,0 +1,46 @@
+---
+name: Test & Release
+
+on: workflow_dispatch
+
+jobs:
+  pre-commit:
+    name: run pre-commit hook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - uses: pre-commit/action@v2.0.0
+
+  test:
+    name: run tox tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install krb5-config
+        run: sudo apt update && sudo apt-get install libkrb5-dev  # krb5-config missing distro dependency
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py
+
+  release:
+    name: mrack semantic release
+    runs-on: ubuntu-latest
+    needs: [pre-commit, test]
+    if: github.repository == 'neoave/mrack'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Python Semantic Release
+        uses: relekang/python-semantic-release@v7.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mrack
 
+![pypi_badge](https://img.shields.io/pypi/v/mrack?label=PyPI&logo=pypi) ![readthedocs_badge](https://img.shields.io/readthedocs/mrack?label=Read%20the%20Docs&logo=read-the-docs)
+
 **Important**: most of the described below is not implemented yet
 
 Provisioning library for CI and local multi-host testing supporting multiple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,13 @@ multi_line_output = 3
 markers = [
     "etc_hosts: passes path for etc_hosts fixture",
 ]
+
+[tool.semantic_release]
+version_source = "commit"
+version_variable = [
+    "src/mrack/__init__.py:__version__",
+    "docs/conf.py:release",
+]
+branch = "master"
+commit = true
+tag = true

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 # -*- coding: utf-8 -*-
+import re
+import sys
+
 from setuptools import find_packages, setup
 
 with open("README.md") as f:
@@ -21,12 +24,23 @@ with open("README.md") as f:
 with open("requirements.txt") as req:
     reqs = req.readlines()
 
+with open("src/mrack/__init__.py", "r") as fd:
+    version = re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
+    )
+    if version is None:
+        sys.stderr.write("Could not parse the version string.\n")
+        exit(1)
+
+    mrack_version = version.group(1)
+
+
 mrack_conf = "mrack.conf"
 prov_conf = "provisioning-config.yaml"
 
 setup(
     name="mrack",
-    version="0.3.0",
+    version=mrack_version,
     description="Multicloud use-case based multihost async provisioner "
     "for CIs and testing during development",
     long_description=readme,

--- a/src/mrack/__init__.py
+++ b/src/mrack/__init__.py
@@ -1,4 +1,6 @@
 """mrack library."""
+__version__ = "0.3.0"
+
 import logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Added release workflow to be run by hand:
![workflow-image](https://i.imgur.com/Q2Frf7F.png)
This workflow depends on test and pre-commit runs:
![dep-image](https://i.imgur.com/BEPU4cn.png)
And after these succeeds runs the python-semantic-release action:
![release-image](https://i.imgur.com/pTaOHYw.png)
In this action:
- a new commit with changed version and changelog is pushed to master
- a new tag is added to the commit above with particular release version
- a new mrack package is being release to PyPi (prerequisite: secret with PYPI_TOKEN - already set)

Please note: the release 0.3.1 will not be created becaue it has been already this is why test action is failing here: https://github.com/Tiboris/mrack/runs/1448905490?check_suite_focus=true (see: https://pypi.org/help/#file-name-reuse)

