### PR TITLE
fix: Remove double status translation in parse_errors

### DIFF
--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -129,7 +129,7 @@ class Provider:
         logger.debug(f"{self.dsp_name}: Checking provisioned hosts for errors")
         for host in hosts:
             logger.debug(f"{self.dsp_name}: Host - {host.id}\tStatus - {host.status}")
-            if self.STATUS_MAP.get(host.status, STATUS_OTHER) == STATUS_ERROR:
+            if host.status == STATUS_ERROR:
                 errors.append(host.error)
 
         return errors


### PR DESCRIPTION
When rebasing the Podman provider I've noticed this bug. It was failing for Podman as it has no STATUS_MAP but the line is IMHO incorrect for all others. It may be hard to notice as it defaults to STATUS_OTHER. I did not test if it works though.

Description:

parse_errors works with Host objects which already have the normalized status so usage of STATUS_MAP is incorrect.

