### PR TITLE
fix: AWS Error for non authorized user reading image + refactor overcomplicated join

### DIFF
--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -88,6 +88,12 @@ class AWSProvider(Provider):
 
             try:
                 aws_image = self.ec2.Image(req_img)
+                if not aws_image:  # user is not authorized to use ami - None returned
+                    raise ValidationError(
+                        f"{self.dsp_name}: User does not have enough permissions "
+                        f"to use image: {req_img}"
+                    )
+
                 logger.info(
                     f"{self.dsp_name}: Requested provisioning of {aws_image.name} image"
                 )
@@ -98,7 +104,7 @@ class AWSProvider(Provider):
                 )
                 logger.error(err_msg)
                 err_resp = image_err.response["Error"]["Message"]
-                raise ValidationError(f"{err_msg} Request failed with {err_resp}")
+                raise ValidationError(f"{err_msg}. Request failed with {err_resp}")
 
         return
 

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -288,11 +288,7 @@ class OpenStackProvider(Provider):
             set([req["image"] for req in reqs if req["image"] not in self.images])
         )
         if prepare_images:
-            if len(prepare_images) > 1:
-                im_list = ", ".join(prepare_images)
-            else:
-                im_list = prepare_images.pop()
-
+            im_list = ", ".join(prepare_images)
             logger.debug(f"{self.dsp_name}: Loading image info for: '{im_list}'")
             await self.load_images(list(prepare_images))
             logger.debug(f"{self.dsp_name}: Loading images info done.")


### PR DESCRIPTION
There was an issue when reading image.name for image
for which user did not have proper read rights and
is not authorised to use it - Nonetype has no attribute name

refactor overcomplicated code in openstack in second commit

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>