### PR TITLE
fix: mrack.conf '~' causes no such file or directory

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -101,7 +101,7 @@ class BeakerProvider(Provider):
 
     def _allow_ssh_key(self, ssh_key):
 
-        with open(ssh_key, "r") as key_file:
+        with open(os.path.expanduser(ssh_key), "r") as key_file:
             key_content = key_file.read()
 
         return [

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -20,6 +20,7 @@ import contextlib
 import datetime
 import json
 import logging
+import os
 import sys
 
 import yaml
@@ -79,14 +80,14 @@ def json_convertor(obj):
 
 def load_json(path):
     """Load JSON file into Python object."""
-    with open(path, "r") as file_data:
+    with open(os.path.expanduser(path), "r") as file_data:
         data = json.load(file_data)
     return data
 
 
 def load_yaml(path):
     """Load YAML file into Python object."""
-    with open(path, "r") as file_data:
+    with open(os.path.expanduser(path), "r") as file_data:
         data = yaml.safe_load(file_data)
     return data
 
@@ -94,7 +95,7 @@ def load_yaml(path):
 def save_to_json(path, data):
     """Serialize object into JSON file."""
     try:
-        with open(path, "w") as output:
+        with open(os.path.expanduser(path), "w") as output:
             json.dump(data, output, default=json_convertor, indent=2, sort_keys=True)
     except IOError as exc:
         logger.exception(exc)
@@ -105,7 +106,7 @@ def save_to_json(path, data):
 def fd_open(filename=None):
     """Use file or stout as output file descriptor."""
     if filename:
-        fd = open(filename, "w")
+        fd = open(os.path.expanduser(filename), "w")
     else:
         fd = sys.stdout
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -10,7 +10,7 @@ def test_dir_path():
 
 def get_data(name, data_dir="data"):
     path = os.path.join(test_dir_path(), data_dir, name)
-    with open(path, "r") as file_data:
+    with open(os.path.expanduser(path), "r") as file_data:
         data = json.load(file_data)
     return data
 


### PR DESCRIPTION
When `~` is used in path for mrack.conf the later
operation open('`~/.mrack/mrackdb.json`', 'w') fails with an
exception FileNotFoundError:
[Errno 2] No such file or directory: '~/.mrack/mrackdb.json'

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>