### PR TITLE
fix: Fix making ssh_key_filename absolute for default behavior.

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -14,6 +14,7 @@
 
 """Ansible inventory output module."""
 import logging
+import os
 import typing
 from copy import deepcopy
 
@@ -156,7 +157,7 @@ class AnsibleInventoryOutput:
             host_info["meta_parent_domain"] = meta_domain["parent"]
 
         if ssh_key:
-            host_info["ansible_ssh_private_key_file"] = ssh_key
+            host_info["ansible_ssh_private_key_file"] = os.path.abspath(ssh_key)
 
         if password:
             host_info["ansible_password"] = password

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -117,10 +117,10 @@ class PytestMultihostOutput:
 
         # ssh_key_filename must be absolute as it can be used from a different
         # working directory, e.g. running tests from git repo
-        ssh_key_filename = self._config.get("ssh_key_filename")
+        ssh_key_filename = mhcfg.get("ssh_key_filename")
 
         # Update with SSH key path only if not already defined in mhcfg
-        if ssh_key_filename and not mhcfg.get("ssh_key_filename"):
+        if ssh_key_filename and not self._metadata.get("ssh_key_filename"):
             mhcfg["ssh_key_filename"] = os.path.abspath(ssh_key_filename)
 
         return mhcfg


### PR DESCRIPTION
The logic was not working as the comment said. The cause was that
`mhcfg` already contained the value from provisioning config. So
we need to check the metadata to detect the situation.
