### PR TITLE
fix: pytest-multihost: handle unresolvable IP into DNS

### DIFF
--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -94,7 +94,12 @@ class PytestMultihostOutput:
                 ip = provisioned_host.ip
                 dns_record = resolve_hostname(ip)
                 host["ip"] = ip
-                host["external_hostname"] = dns_record
+
+                # Using IP as backup for external host name as pytest-multihost is using
+                # external_hostname as the host to use in ssh command.
+                # If it is not available it uses hostname, but we assume here that
+                # hostname is internal and thus not resolvable. IP should be resolvable.
+                host["external_hostname"] = dns_record or ip
 
                 if host["group"] == "ad_root":
                     mhcfg["ad_top_domain"] = domain["name"]


### PR DESCRIPTION
If host IP was not resolvable into DNS record, external_hostname was
null and thus pytest-multihost could not connect to the host.

This resolves the issue with using IP as a backup.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>