### PR TITLE
feat: Retry provisioning strategy

### DIFF
--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -24,7 +24,7 @@ from botocore.exceptions import ClientError
 
 from mrack.errors import ProvisioningError, ValidationError
 from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_PROVISIONING
-from mrack.providers.provider import Provider
+from mrack.providers.provider import STRATEGY_ABORT, Provider
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,7 @@ class AWSProvider(Provider):
         """Object initialization."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "AWS"
+        self.strategy = STRATEGY_ABORT
         self.ami_ids: typing.List[str] = []
         self.ssh_key = None
         self.sec_group = None

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -35,7 +35,7 @@ from mrack.host import (
     STATUS_OTHER,
     STATUS_PROVISIONING,
 )
-from mrack.providers.provider import Provider
+from mrack.providers.provider import STRATEGY_ABORT, Provider
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ class BeakerProvider(Provider):
         """Object initialization."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "Beaker"
+        self.strategy = STRATEGY_ABORT
         self.conf = PyConfigParser()
         self.poll_sleep = 30  # seconds
         self.keypair = None

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -341,7 +341,8 @@ class OpenStackProvider(Provider):
         * 'network': uuid or name of network to use. Will be added to networks
                      list if present
         """
-        logger.info(f"{self.dsp_name}: Creating server")
+        name = req.get("name")
+        logger.info(f"{self.dsp_name}: Creating server {name}")
         specs = deepcopy(req)  # work with own copy, do not modify the input
 
         flavor = self._translate_flavor(req)

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -25,7 +25,7 @@ from simple_rest_client.exceptions import NotFoundError
 
 from mrack.errors import ServerNotFoundError, ValidationError
 from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_PROVISIONING
-from mrack.providers.provider import Provider
+from mrack.providers.provider import STRATEGY_RETRY, Provider
 from mrack.providers.utils.osapi import ExtraNovaClient, NeutronClient
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,8 @@ class OpenStackProvider(Provider):
         """Object initialization."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "OpenStack"
+        self.strategy = STRATEGY_RETRY
+        self.max_attempts = 5  # provisioning retries
         self.flavors = {}
         self.flavors_by_ref = {}
         self.images = {}

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -22,6 +22,9 @@ from mrack.host import STATUS_ERROR, STATUS_OTHER, Host
 
 logger = logging.getLogger(__name__)
 
+STRATEGY_ABORT = "abort"
+STRATEGY_RETRY = "retry"
+
 
 class Provider:
     """General Provider interface."""
@@ -30,6 +33,7 @@ class Provider:
         """Initialize provider."""
         self._name = "dummy"
         self.dsp_name = "Dummy"
+        self.strategy = STRATEGY_ABORT
         self.STATUS_MAP = {"OTHER": STATUS_OTHER}
         return
 
@@ -54,36 +58,23 @@ class Provider:
         """Wait till resource is provisioned."""
         raise NotImplementedError()
 
-    async def provision_hosts(self, hosts):
+    async def _provision_base(self, reqs):
         """Provision hosts based on list of host requirements.
 
-        Main provider method for provisioning.
-
-        First it validates that host requirements are valid and that
-        provider has enough resources(quota).
-
-        Then issues provisioning and waits for it succeed. Raises exception if any of
-        the servers was not successfully provisioned. If that happens it issues deletion
-        of all already provisioned resources.
-
-        Return list of information about provisioned servers.
+        Main function which does provisioning and not any validation.
         """
-        logger.info(f"{self.dsp_name}: Validating hosts definitions")
-        await self.validate_hosts(hosts)
         logger.info(f"{self.dsp_name}: Host definitions valid")
 
         logger.info(f"{self.dsp_name}: Checking available resources")
-        can = await self.can_provision(hosts)
+        can = await self.can_provision(reqs)
         if not can:
             raise ValidationError(f"{self.dsp_name}: Not enough resources to provision")
         logger.info(f"{self.dsp_name}: Resource availability: OK")
-
         started = datetime.now()
-
-        count = len(hosts)
+        count = len(reqs)
         logger.info(f"{self.dsp_name}: Issuing provisioning of {count} hosts")
         create_servers = []
-        for req in hosts:
+        for req in reqs:
             awaitable = self.create_server(req)
             create_servers.append(awaitable)
         create_resps = await asyncio.gather(*create_servers)
@@ -106,33 +97,96 @@ class Provider:
         logger.info(f"{self.dsp_name}: Provisioning duration: {provi_duration}")
 
         hosts = [self.to_host(srv) for srv in server_results]
-        errors = self.parse_errors(hosts)
+        error_hosts = self.parse_error_hosts(hosts)
+        success_hosts = [h for h in hosts if h not in error_hosts]
+        error_host_names = [host.name for host in error_hosts]
+        missing_reqs = [req for req in reqs if req["name"] in error_host_names]
+        return (success_hosts, error_hosts, missing_reqs)
 
-        if errors:
-            logger.info(f"{self.dsp_name}: Some host did not start properly")
-            for host_err in errors:
-                logger.error(f"{self.dsp_name}: Error: {str(host_err)}")
+    async def provision_hosts(self, reqs):
+        """Provision hosts based on list of host requirements.
 
-            logger.info(f"{self.dsp_name}: Given the error, will delete all hosts")
-            await self.delete_hosts(hosts)
-            raise ProvisioningError(errors)
+        Main provider method for provisioning.
+
+        First it validates that host requirements are valid and that
+        provider has enough resources(quota).
+
+        Then issues provisioning and waits for it succeed. Raises exception if any of
+        the servers was not successfully provisioned. If that happens it issues deletion
+        of all already provisioned resources.
+
+        Return list of information about provisioned servers.
+        """
+        logger.info(f"{self.dsp_name}: Validating hosts definitions")
+        await self.validate_hosts(reqs)
+
+        if self.strategy == STRATEGY_RETRY:
+            success_hosts, error_hosts, missing_reqs = await self.strategy_retry(reqs)
+        else:
+            success_hosts, error_hosts, missing_reqs = await self.strategy_abort(reqs)
+
+        if error_hosts:
+            hosts_to_delete = success_hosts + error_hosts
+            self.abort_and_delete(hosts_to_delete, error_hosts)
 
         logger.info(f"{self.dsp_name}: Printing provisioned hosts")
-        for host in hosts:
+        for host in success_hosts:
             logger.info(f"{self.dsp_name}: {host}")
 
-        return hosts
+        return success_hosts
 
-    def parse_errors(self, hosts):
+    async def strategy_retry(self, reqs):
+        """Provisioning strategy to try multiple times to provision a host."""
+        missing_reqs = reqs
+        attempts = 0
+        success_hosts = []
+        error_hosts = []
+
+        while missing_reqs:
+            if attempts >= self.max_attempts:
+                logger.error(f"Max attempts({self.max_attempts}) reached. Aborting.")
+                break
+
+            attempts += 1
+            s_hosts, error_hosts, missing_reqs = await self._provision_base(
+                missing_reqs
+            )
+            success_hosts.extend(s_hosts)
+
+            if error_hosts:
+                count = len(error_hosts)
+                err = f"{count} hosts were not provisioned properly, deleting."
+                logger.info(f"{self.dsp_name}: {err}")
+                for host in error_hosts:
+                    logger.error(f"{self.dsp_name}: Error: {str(host.error)}")
+                await self.delete_hosts(error_hosts)
+                logger.info("Retrying to provision these hosts.")
+
+        return success_hosts, error_hosts, missing_reqs
+
+    async def strategy_abort(self, reqs):
+        """Provisioning strategy to try once and then abort."""
+        return await self._provision_base(reqs)
+
+    def parse_error_hosts(self, hosts):
         """Parse provisioning errors from provider result."""
         errors = []
         logger.debug(f"{self.dsp_name}: Checking provisioned hosts for errors")
         for host in hosts:
             logger.debug(f"{self.dsp_name}: Host - {host.id}\tStatus - {host.status}")
             if host.status == STATUS_ERROR:
-                errors.append(host.error)
-
+                errors.append(host)
         return errors
+
+    async def abort_and_delete(self, hosts_to_delete, error_hosts):
+        """Delete hosts and abort provisioning with an error."""
+        logger.info(f"{self.dsp_name}: Aborting provisioning due to error.")
+        for host in error_hosts:
+            logger.error(f"{self.dsp_name}: Error: {str(host.error)}")
+
+        logger.info(f"{self.dsp_name}: Given the error, will delete hosts")
+        await self.delete_hosts(hosts_to_delete)
+        raise ProvisioningError(error_hosts)
 
     async def delete_host(self, host_id):
         """Delete provisioned host."""

--- a/src/mrack/providers/static.py
+++ b/src/mrack/providers/static.py
@@ -16,7 +16,7 @@
 
 from mrack.errors import ValidationError
 from mrack.host import STATUS_ACTIVE, Host
-from mrack.providers.provider import Provider
+from mrack.providers.provider import STRATEGY_ABORT, Provider
 
 PROVISIONER_KEY = "static"
 
@@ -32,6 +32,7 @@ class StaticProvider(Provider):
     def __init__(self):
         """Object initialization."""
         self._name = PROVISIONER_KEY
+        self.strategy = STRATEGY_ABORT
 
     async def validate_hosts(self, reqs):
         """Validate that host requirements are well specified."""


### PR DESCRIPTION
Optional (currently applied only for OpenStack) provisioning strategy
to retry provisioning of host which ended with error in a provisioning
attempt.

This is useful if environment gets into state where the provisioning
is a bit unstable but in general working. I.e. succeeds for some host
and fails for others.

The Retry strategy:
1. tries to provision all hosts
2. if some failed, delete them and retry only for these hosts
3. if they fail more than max_attempts time(default: 5), fail the job

Default strategy:
- do 1.
- if some failed, fail the job

In each job failure case:
- delete all hosts

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>