### PR TITLE
fix: load possible missing image specified in metadata

### DIFF
--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -72,6 +72,10 @@ class AWSProvider(Provider):
         self.sec_group = sec_group
         self.instance_tags = instance_tags
 
+    async def prepare_provisioning(self, reqs):
+        """Prepare provisioning."""
+        pass
+
     async def validate_hosts(self, hosts):
         """Validate that host requirements are well specified."""
         for req in hosts:

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -96,6 +96,10 @@ class BeakerProvider(Provider):
                 )
         return
 
+    async def prepare_provisioning(self, reqs):
+        """Prepare provisioning."""
+        pass
+
     async def can_provision(self, hosts):
         """Check that hosts can be provisioned."""
         return True

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -278,6 +278,25 @@ class OpenStackProvider(Provider):
 
         return True
 
+    async def prepare_provisioning(self, reqs):
+        """
+        Prepare provisioning.
+
+        Load missing images if they are not in provisioning-config.yaml
+        """
+        prepare_images = list(
+            set([req["image"] for req in reqs if req["image"] not in self.images])
+        )
+        if prepare_images:
+            if len(prepare_images) > 1:
+                im_list = ", ".join(prepare_images)
+            else:
+                im_list = prepare_images.pop()
+
+            logger.debug(f"{self.dsp_name}: Loading image info for: '{im_list}'")
+            await self.load_images(list(prepare_images))
+            logger.debug(f"{self.dsp_name}: Loading images info done.")
+
     async def validate_hosts(self, reqs):
         """Validate that all hosts requirements contains existing required objects."""
         for req in reqs:

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -58,6 +58,10 @@ class Provider:
         """Wait till resource is provisioned."""
         raise NotImplementedError()
 
+    async def prepare_provisioning(self, reqs):
+        """Prepare provisioning."""
+        raise NotImplementedError()
+
     async def _provision_base(self, reqs):
         """Provision hosts based on list of host requirements.
 
@@ -117,6 +121,9 @@ class Provider:
 
         Return list of information about provisioned servers.
         """
+        logger.info(f"{self.dsp_name}: Preparing provider resources")
+        await self.prepare_provisioning(reqs)
+
         logger.info(f"{self.dsp_name}: Validating hosts definitions")
         await self.validate_hosts(reqs)
 


### PR DESCRIPTION
When openstack image was not in provisioning config
it was not loaded to known images.
Now we try to load missing images and store to provider's
known images if they were specified in metadata but not
in provisioning-config.yaml

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>