### PR TITLE
chore: change pinned version from strict to range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-beaker-client==28
+beaker-client>=28
 botocore==1.18.18
 boto3==1.15.18
-click==7.1.2
-pyyaml==5.3.1
-asyncopenstackclient==0.8.1
+click>=7.0.0
+pyyaml>=5.0.0
+asyncopenstackclient>=0.8.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 black==20.8b1
-isort==5.6.4
-flake8==3.8.4
-pytest==6.1.2
-pytest-asyncio==0.14.0
-pydocstyle==5.1.1
+isort>=5.0.0
+flake8>=3.0.0
+pytest>=6.0.0
+pytest-asyncio>=0.14.0
+pydocstyle>=5.0.0


### PR DESCRIPTION
While still a good practice to pin the versions of dependencies we found some issues with conflicting dependencies.

This change tries to install greater than or equal to latest major version (or minor if versio is 0.X).

It keeps the exact version (`==`) for boto3 and botocore because of a known conflict in the production environment.

Signed-off-by: Armando Neto <abiagion@redhat.com>