### PR TITLE
fix: mrack eh add no longer complains about coroutine 'eh' not awaited

### DIFF
--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -208,14 +208,13 @@ async def ssh(ctx, hostname, metadata):
 
 
 @mrackcli.group()
-async def eh():
+def eh():
     """Commands to update /etc/hosts file."""
 
 
 @eh.command()
 @click.pass_context
-@async_run
-async def add(ctx):
+def add(ctx):
     """Add active hosts to /etc/hosts file."""
     eh_action = EtcHostsUpdate(ctx.obj[DB])
     eh_action.update()
@@ -223,8 +222,7 @@ async def add(ctx):
 
 @eh.command()
 @click.pass_context
-@async_run
-async def clear(ctx):
+def clear(ctx):
     """Remove all mrack hosts from /etc/hosts file."""
     eh_action = EtcHostsUpdate(ctx.obj[DB])
     eh_action.clear()


### PR DESCRIPTION
Turns:
```
$ mrack eh add
/usr/lib/python3.9/site-packages/click/core.py:1256: RuntimeWarning: coroutine 'eh' was never awaited
  Command.invoke(self, ctx)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Adding hosts to /etc/hosts file
Done
```

Into:
```
$ mrack eh add
Adding hosts to /etc/hosts file
Done
```

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>