### PR TITLE
refactor: Fix missing param in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To provision system from the metadata.yaml either run:
 ```
 mrack up
 ```
-or use `up` command's option ``/`-m` to orverride path to the metadata file.
+or use `up` command's option `--metadata`/`-m` to orverride path to the metadata file.
 ```
 mrack up --metadata other-metadata.yaml
 ```


### PR DESCRIPTION
Fix missing param in README.md file `--metadata`

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>