### PR TITLE
fix: Handle ServerError in OpenStack provisioning

### DIFF
--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -72,10 +72,14 @@ class OpenStackTransformer(Transformer):
         usable = []
         for network in networks:
             ips = self._provider.get_ips(ref=network.get("id"))
+
             available = ips["total_ips"] - ips["used_ips"]
+            logger.debug(f"Network: {network['name']}")
+            logger.debug(f"  total: {ips['total_ips']}")
+            logger.debug(f"  used: {ips['used_ips']}")
+            logger.debug(f"  available: {available}")
             if available > count:
                 usable.append((network["name"], available))
-
         if not usable:
             logger.error(
                 f"{self.dsp_name}: Error: no usable network"


### PR DESCRIPTION
fix: more verbose print about available networks
    
So that we can see more details in debugging.

fix: Handle ServerError in OpenStack provisioning
    
If OpenStack server returns e.g. error 503, provider code doesn't handle it well and whole Mrack fails. This should catch it with    certain error tolerance/retry - e.g. if it was a fluke.
