### PR TITLE
feat: OpenStack: increase polling time based on number of hosts

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -225,17 +225,9 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
 
         return resources[0] if len(resources) == 1 else []
 
-    async def wait_till_provisioned(
-        self, bkr_id_req_name, timeout=None, poll_sleep=None, max_attempts=None
-    ):
+    async def wait_till_provisioned(self, bkr_id_req_name):
         """Wait for Beaker provisioning result."""
         beaker_id, req_name = bkr_id_req_name
-
-        if not poll_sleep:
-            poll_sleep = self.poll_sleep
-        if not max_attempts:
-            max_attempts = self.max_attempts
-
         resource = {}
         attempts = 0
         prev_status = ""


### PR DESCRIPTION
Increase polling times so that Mrack doesn't poll very often to not overload the server when a lot of hosts is provisioned.

Current setting should be approx:
```
hosts   init_wait   poll_time   After 10mins    After 15mins
    1       15.65        7.22          48.77           69.55
    3       16.95        7.66          46.82           66.41
    7       19.55        8.54          43.67           61.23
   10       21.50        9.20          41.81           58.11
   30       34.50       13.60          35.66           46.69
  100       80.00       29.00          39.34           44.52
  200      145.00       51.00          56.88           59.82
```

Where "After 10/15mins" is poll_time after the time, but it is not a precise value (did not want to spend time on calculating it).