### PR TITLE
fix: OpenStack provider does not crash if no credentials are provided

### DIFF
--- a/src/mrack/errors.py
+++ b/src/mrack/errors.py
@@ -75,3 +75,9 @@ class ProvisioningError(ProviderError):
     """Error happened during provisioning of resources."""
 
     pass
+
+
+class NotAuthenticatedError(ProviderError):
+    """Provided is not authenticated."""
+
+    pass


### PR DESCRIPTION
If OpenStack RC file is not loaded, openstack provider failed with
unhandled TypeError exception which is thrown by asyncopenstackclient
AuthPassword.

This fix catches the exception and writes friendly error message.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>