### PR TITLE
fix: Require beaker version with support for python 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beaker-client>=28
+beaker-client>=28.1
 botocore==1.18.18
 boto3==1.15.18
 click>=7.0.0


### PR DESCRIPTION
Python 3.9 has removed the deprecated method 'encodestring' from base64 module.
It needs to be replaced by 'encodebytes'.
Beaker version 28.1 has the fix in place so require at least this
version.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>