### PR TITLE
fix: podman ansible inventory and status_map for podman

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -165,7 +165,7 @@ class AnsibleInventoryOutput:
         if db_host.provider.name in ("docker", "podman"):
             host_info.update(
                 {
-                    "ansible_host": db_host.id,
+                    "ansible_host": db_host.host_id,
                     "ansible_connection": db_host.provider.name,
                     "ansible_user": "root",  # TODO make it configurable in provider
                 },

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -20,7 +20,7 @@ from datetime import datetime, timedelta
 
 from mrack.errors import ProvisioningError, ServerNotFoundError
 from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_OTHER
-from mrack.providers.provider import Provider
+from mrack.providers.provider import STRATEGY_ABORT, Provider
 from mrack.providers.utils.podman import Podman
 from mrack.utils import object2json
 
@@ -36,7 +36,13 @@ class PodmanProvider(Provider):
         """Initialize provider."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "Podman"
+        self.strategy = STRATEGY_ABORT
         self.podman = Podman()
+        self.status_map = {
+            STATUS_ACTIVE: STATUS_ACTIVE,
+            STATUS_DELETED: STATUS_DELETED,
+            STATUS_ERROR: STATUS_ERROR,
+        }
 
     async def prepare_provisioning(self, reqs):
         """Prepare provisioning."""


### PR DESCRIPTION
Fixing ansible inventory generation for podman because db_host has no
attribute id.
Fixing AttributeError: 'PodmanProvider' object has no attribute 'strategy'.
Adding status map to podman

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>