### PR TITLE
chore: change boto's minimum version required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beaker-client>=28.1
-botocore==1.18.18
-boto3==1.15.18
+botocore>=1.14.17
+boto3>=1.11.17
 click>=7.0.0
 pyyaml>=5.0.0
 asyncopenstackclient>=0.8.1


### PR DESCRIPTION
Replace exact versions of boto3 and boto-core with "greater than" and setting an older version because it's the latest available for Fedora 32.

It will install latest via pypi, pinned version is not a requirement anymore because production conflicts with linchpin are not a problem anymore.

Signed-off-by: Armando Neto <abiagion@redhat.com>