### PR TITLE
chore: Update project homepage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Petr Vobornik",
     author_email="pvoborni@redhat.com",
-    url="https://github.com/pvoborni/mrack",
+    url="https://github.com/neoave/mrack",
     license="Apache License 2.0",
     packages=find_packages("src"),
     package_dir={"": "src"},


### PR DESCRIPTION
Fix URL used by Python Package Index.

---

**Note:** A webhook is configured to notify COPR when a release is published.

We can use this commit to test that.