### PR TITLE
chore: Trigger COPR to build rpm

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -66,3 +66,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}
+      - name: Trigger COPR build
+        run: curl -X POST ${{ secrets.COPR_WEBHOOK_URL }}


### PR DESCRIPTION
Add action step to trigger COPR after a new release is created.

Using Github's built-in webhooks failed to talk to COPR "after release", so this should be more reliable.

--- 
**TO DO:**
- [x] Add secret to repo