### PR TITLE
feat: Advanced podman support and several minor updates and bugfixes

### DIFF
--- a/src/mrack/actions/ssh.py
+++ b/src/mrack/actions/ssh.py
@@ -127,7 +127,7 @@ class SSH:
         """Simulate SSH by attaching an interactive session to a container."""
         if host.provider.name == "podman":
             podman = Podman()
-            podman.interactive(host.id)
+            podman.interactive(host.host_id)
         else:
             raise NotImplementedError("Docker is not yet supported.")
 

--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -58,7 +58,7 @@ beaker:  # beaker provider specific values
         fedora-32: Fedora-32%
 
     # path to public ssh key which is later uploaded to the machine for access
-    keypair: id_rsa.pub
+    pubkey: id_rsa.pub
     # default reservation time for the beaker job
     reserve_duration: 86400
     # default max_attepmts value for the beaker job

--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -1,4 +1,35 @@
 ---
+podman:
+    images:
+        # example: systemd enabled container images from: https://github.com/Tiboris/snappeas
+        fedora-rawhide: tdudlak/snappeas:fedora-rawhide
+
+    pubkey: config/id_rsa.pub
+
+    # this will be used as prefix for the network name
+    default_network: mrack
+
+    # advanced podman options to be passed to every execution of podman run eg:
+    # NOTE: when 'key' in podman_options has list assigned as value
+    #       the option specidfied by the 'key' is added multiple times
+    #       if it has only one value the option is used once
+    podman_options:
+        # Add Linux capabilities.
+        "--cap-add":
+            - "ALL"
+        # Allowed syscall list seccomp JSON file to be used as a seccomp filter
+        "--security-opt": "seccomp=src/mrack/data/seccomp.json"
+        # Mount a temporary filesystems (tmpfs) into a container
+        "--tmpfs":
+            - "/tmp"
+            - "/run"
+            - "/run/lock"
+        # Use /sys/fs/cgroup in container as read only volume
+        "-v":
+            - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+        # Adding ipv6 support to network
+        "--network": "enable_ipv6=true"
+
 aws:  # aws provider config
     images:
         # list of ami images key is used in metadata ami image is used for provider e.g.

--- a/src/mrack/data/seccomp.json
+++ b/src/mrack/data/seccomp.json
@@ -1,0 +1,788 @@
+{
+	"defaultAction": "SCMP_ACT_LOG",
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_AARCH64",
+			"subArchitectures": [
+				"SCMP_ARCH_ARM"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_S390X",
+			"subArchitectures": [
+				"SCMP_ARCH_S390"
+			]
+		}
+	],
+	"syscalls": [
+		{
+			"names": [
+				"accept",
+				"accept4",
+				"access",
+				"adjtimex",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_adjtime",
+				"clock_getres",
+				"clock_gettime",
+				"clock_nanosleep",
+				"close",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"faccessat2",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futimesat",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"get_robust_list",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"get_thread_area",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"ioctl",
+				"io_destroy",
+				"io_getevents",
+				"ioprio_get",
+				"ioprio_set",
+				"io_setup",
+				"io_submit",
+				"ipc",
+				"kill",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"_llseek",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"memfd_create",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedsend",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"nanosleep",
+				"newfstatat",
+				"_newselect",
+				"open",
+				"openat",
+				"pause",
+				"pipe",
+				"pipe2",
+				"poll",
+				"ppoll",
+				"prctl",
+				"pread64",
+				"preadv",
+				"preadv2",
+				"prlimit64",
+				"pselect6",
+				"pwrite64",
+				"pwritev",
+				"pwritev2",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_tgsigqueueinfo",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"set_robust_list",
+				"setsid",
+				"setsockopt",
+				"set_thread_area",
+				"set_tid_address",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigreturn",
+				"socket",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"statx",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_settime",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_settime",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"utime",
+				"utimensat",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev",
+				"mount",
+				"umount2",
+				"reboot",
+				"name_to_handle_at",
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 0,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 8,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131072,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131080,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 4294967295,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"sync_file_range2"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"ppc64le"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
+				"sync_file_range2",
+				"breakpoint",
+				"cacheflush",
+				"set_tls"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"arm",
+					"arm64"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arch_prctl"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"modify_ldt"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32",
+					"x86"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"s390_pci_mmio_read",
+				"s390_pci_mmio_write",
+				"s390_runtime_instr"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"bpf",
+				"clone",
+				"fanotify_init",
+				"lookup_dcookie",
+				"mount",
+				"name_to_handle_at",
+				"perf_event_open",
+				"quotactl",
+				"setdomainname",
+				"sethostname",
+				"setns",
+				"syslog",
+				"umount",
+				"umount2",
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				],
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 1,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "s390 parameter ordering for clone is different",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"reboot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_BOOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"kcmp",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"settimeofday",
+				"stime",
+				"clock_settime"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_NICE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"syslog"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYSLOG"
+				]
+			},
+			"excludes": {}
+		}
+	]
+}

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -141,6 +141,7 @@ class AnsibleInventoryOutput:
             "ansible_user": ansible_user,
             "meta_fqdn": name,
             "meta_domain": meta_domain["name"],
+            "meta_provider": db_host.provider.name,
             "meta_provider_id": db_host.host_id,
             "meta_ip": ip_addr,
             "meta_dc_record": ",".join(
@@ -163,13 +164,7 @@ class AnsibleInventoryOutput:
             host_info["ansible_password"] = password
 
         if db_host.provider.name in ("docker", "podman"):
-            host_info.update(
-                {
-                    "ansible_host": db_host.host_id,
-                    "ansible_connection": db_host.provider.name,
-                    "ansible_user": "root",  # TODO make it configurable in provider
-                },
-            )
+            host_info.update({"ansible_user": "root"})  # TODO make it configurable
 
         if is_windows_host(meta_host):
             if "netbios" in meta_host:

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -59,7 +59,7 @@ class PodmanProvider(Provider):
     async def create_server(self, req):
         """Request and create resource on selected provider."""
         hostname = req["name"]
-        logger.info(f"Creating container for host: {hostname}")
+        logger.info(f"{self.dsp_name}: Creating container for host: {hostname}")
         hostname = req["name"]
         image = req["image"]
         network = req.get("network")
@@ -78,7 +78,7 @@ class PodmanProvider(Provider):
             try:
                 inspect = await self.podman.inspect(cont_id)
             except ProvisioningError as err:
-                logger.error(object2json(err))
+                logger.error(f"{self.dsp_name}: {object2json(err)}")
                 raise ServerNotFoundError(cont_id) from err
             server = inspect[0]
             running = server["State"]["Running"]
@@ -92,12 +92,15 @@ class PodmanProvider(Provider):
 
         if datetime.now() >= timeout_time:
             logger.warning(
-                f"{cont_id} was not provisioned within a timeout of" f" {timeout} mins"
+                f"{self.dsp_name}: {cont_id} was not provisioned within a timeout of"
+                f" {timeout} mins"
             )
         else:
-            logger.info(f"{cont_id} was provisioned in {prov_duration:.1f}s")
+            logger.info(
+                f"{self.dsp_name}: {cont_id} was provisioned in {prov_duration:.1f}s"
+            )
 
-        logger.debug(object2json(server))
+        logger.debug(f"{self.dsp_name}: Resource: {object2json(server)}")
         return server
 
     async def delete_host(self, host_id):

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -207,3 +207,8 @@ class PodmanProvider(Provider):
         result["status"] = status
 
         return result
+
+    def to_host(self, provisioning_result, username=None):
+        """Transform provisioning result into Host object."""
+        # for containers use always root user
+        return super().to_host(provisioning_result, username="root")

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -75,7 +75,9 @@ class PodmanProvider(Provider):
         logger.info(f"{self.dsp_name}: Creating container for host: {hostname}")
 
         image = req["image"]
-        network = req.get("network", self.default_network)
+        network = req.get(
+            "network", f"{self.default_network}-{req['domain'].replace('.', '-')}"
+        )
         await self.podman.network_create(network)
 
         if not await self.podman.image_exists(image):

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -47,7 +47,7 @@ class Provider:
         raise NotImplementedError()
 
     async def can_provision(self, hosts):
-        """Check that provider has enough resources to provison hosts."""
+        """Check that provider has enough resources to provision hosts."""
         raise NotImplementedError()
 
     async def create_server(self, req):

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -164,4 +164,8 @@ class Podman:
     def interactive(self, container_id):
         """Create interactive session."""
         args = [self.program, "exec", "-ti", container_id, "bash"]
-        subprocess.run(args, text=True, check=True)
+        try:
+            subprocess.run(args, text=True, check=True)
+        except subprocess.CalledProcessError as callerr:
+            if callerr.returncode != 130:
+                raise  # when it was not killed by ctrl + D (signal 2)

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -81,7 +81,6 @@ class Podman:
             args.extend(["--name", hostname.split(".")[0]])
 
         args.append(image)
-
         stdout, _stderr, _process = await self._run_podman(args)
         container_id = stdout.strip()
         return container_id
@@ -113,6 +112,13 @@ class Podman:
         _stdout, _stderr, process = await self._run_podman(args, raise_on_err=False)
         return process.returncode == 0
 
+    async def exec_command(self, container_id, command):
+        """Execute command in selected container."""
+        args = ["exec", container_id, "sh", "-c"]
+        args.append(command)
+        _stdout, _stderr, process = await self._run_podman(args, raise_on_err=False)
+        return process.returncode == 0
+
     async def network_exists(self, network):
         """Check the existence of podman network on system using inspect command."""
         args = ["network", "inspect", network]
@@ -141,6 +147,18 @@ class Podman:
         args = ["network", "remove", network]
         _stdout, _stderr, process = await self._run_podman(args, raise_on_err=False)
 
+        return process.returncode == 0
+
+    async def pull(self, image):
+        """Pull a container image."""
+        args = ["pull", image]
+        _stdout, _stderr, process = await self._run_podman(args, raise_on_err=False)
+        return process.returncode == 0
+
+    async def image_exists(self, image):
+        """Check if a container image exists in local storage."""
+        args = ["image", "exists", image]
+        _stdout, _stderr, process = await self._run_podman(args, raise_on_err=False)
         return process.returncode == 0
 
     def interactive(self, container_id):

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -78,7 +78,7 @@ class Podman:
 
         if hostname:
             args.extend(["-h", hostname])
-            args.extend(["--name", hostname.split(".")[0]])
+            args.extend(["--name", f"{hostname.replace('.', '-')}-{network}"])
 
         args.append(image)
         stdout, _stderr, _process = await self._run_podman(args)

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -26,7 +26,7 @@ class BeakerTransformer(Transformer):
     _config_key = CONFIG_KEY
     _required_config_attrs = [
         "distros",
-        "keypair",
+        "pubkey",
         "reserve_duration",
         "max_attempts",
     ]  # List[str]
@@ -38,7 +38,7 @@ class BeakerTransformer(Transformer):
             distros=self.config["distros"].values(),
             max_attempts=self.config["max_attempts"],
             reserve_duration=self.config["reserve_duration"],
-            keypair=self.config["keypair"],
+            pubkey=self.config["pubkey"],
         )
 
     def _get_bkr_variant(self, host):

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -15,6 +15,7 @@
 """Podman transformer module."""
 
 from mrack.transformers.transformer import Transformer
+from mrack.utils import get_host_from_metadata
 
 CONFIG_KEY = "podman"
 
@@ -43,8 +44,10 @@ class PodmanTransformer(Transformer):
 
     def create_host_requirement(self, host):
         """Create single input for podman provisioner."""
+        _host, domain = get_host_from_metadata(self._metadata, host["name"])
         return {
             "name": host["name"],
             "image": self._get_image(host["os"]),
             "hostname": host["name"],
+            "domain": domain["name"],
         }

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -25,6 +25,7 @@ class PodmanTransformer(Transformer):
     _config_key = CONFIG_KEY
     _required_config_attrs = [
         "images",
+        "pubkey",
         "default_network",
         "podman_options",
     ]
@@ -35,6 +36,7 @@ class PodmanTransformer(Transformer):
 
         await self._provider.init(
             container_images=self.config["images"].values(),
+            ssh_key=self.config["pubkey"],
             default_network=self.config["default_network"],
             container_options=self.config["podman_options"],
         )

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -25,7 +25,19 @@ class PodmanTransformer(Transformer):
     _config_key = CONFIG_KEY
     _required_config_attrs = [
         "images",
+        "default_network",
+        "podman_options",
     ]
+
+    async def init_provider(self):
+        """Initialize associate provider and transformer display name."""
+        self.dsp_name = "Podman"
+
+        await self._provider.init(
+            container_images=self.config["images"].values(),
+            default_network=self.config["default_network"],
+            container_options=self.config["podman_options"],
+        )
 
     def create_host_requirement(self, host):
         """Create single input for podman provisioner."""


### PR DESCRIPTION


## feat: Add capability to use custom podman options

mrack now support advanced podman provisioning
to enable custom way of running pods with podman
we should add podman section to provisioning config
something like:

```
podman:
    images:
        # systemd enabled container images from: https://github.com/Tiboris/snappeas
        fedora-32: tdudlak/snappeas:fedora-32
        fedora-33: tdudlak/snappeas:fedora-33
        fedora-rawhide: tdudlak/snappeas:fedora-rawhide

    pubkey: config/id_rsa.pub

    default_network: mrack-network

    podman_options:
        # Mount a temporary filesystems (tmpfs) into a container
        "--tmpfs":
            - "/tmp"
        # Use /sys/fs/cgroup in container as read only volume
        "-v":
            - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
        # Adding ipv6 support to network
        "--network": "enable_ipv6=true"
```

## feat: Use ssh public key to access container instead of podman id

Use ssh to connect to container provisioned by mrack
instead of ansible connection to prevent some issues
with connection and built in ansible modules so
the container acts like a vm.

## feat: Use more flexible way of defining podman names
    
NETWORK: Podman now use network name created by composing
default network from provisioning config and domain name.
PODS: name of the pod derives from the hostname and network
the pod is assigned to.