### PR TITLE
feat: use ssh to check VM availability after provisioning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         args: ["--ignore-missing-imports"]
 
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.6.0
+    rev: v2.7.4
     hooks:
       - id: pylint
         additional_dependencies: ["isort[pyproject]"]

--- a/src/mrack/actions/up.py
+++ b/src/mrack/actions/up.py
@@ -20,7 +20,7 @@ import logging
 from mrack.errors import MetadataError
 from mrack.providers import providers
 from mrack.transformers import transformers
-from mrack.utils import validate_dict_attrs
+from mrack.utils import global_context, validate_dict_attrs
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +44,14 @@ class Up:
     async def init(self, config, metadata, default_provider, db_driver):
         """Initialize the Up action."""
         self._transformers = {}
+
         self._config = config
         self._metadata = metadata
         self._db_driver = db_driver
         self._required_domain_attrs = ["name", "hosts"]
+
+        global_context["metadata"] = metadata
+        global_context["config"] = config
 
         self.validate_topology()
         default_provider_name = self._config.get("provider", default_provider)

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -207,7 +207,7 @@ async def ssh(ctx, hostname, metadata):
     init_metadata(ctx, metadata)
     ssh_action = SSH()
     ssh_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
-    ssh_action.ssh(hostname)
+    return ssh_action.ssh(hostname)
 
 
 @mrackcli.group()


### PR DESCRIPTION
After a host in provisioned we do check ssh connectivity
to the host itself and claim it is ready only after ssh
connection is successful. If ssh connection fails we
mark this host as an error host delete it and try to
go with reprovision strategy.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>