### PR TITLE
fix: missing error logging while checking the ssh connection

### DIFF
--- a/src/mrack/host.py
+++ b/src/mrack/host.py
@@ -144,6 +144,11 @@ class Host:
         """Get host error object."""
         return self._error
 
+    @error.setter
+    def error(self, value):
+        """Set host error object."""
+        self._error = value
+
     @property
     def username(self):
         """Get username for connecting to host."""

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -93,7 +93,7 @@ class Provider:
                     )
 
         # success ssh return 0 else 1 so we treat it as error in provisioning
-        return ssh_to_host(host, execute="echo mrack")
+        return ssh_to_host(host, command="echo mrack")
 
     async def _provision_base(self, reqs):  # pylint disable=too-many-locals
         """Provision hosts based on list of host requirements.

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -208,10 +208,10 @@ def get_ssh_key(host, meta_host, config):
 
 def ssh_to_host(
     host,
-    execute=None,
     username=None,
     password=None,
     ssh_key=None,
+    command=None,
 ):
     """SSH to the selected host."""
     my_env = os.environ.copy()
@@ -240,8 +240,8 @@ def ssh_to_host(
 
     cmd.append(host.ip_addr)  # Destination
 
-    if execute:
-        cmd.extend(["-C", execute])
+    if command:
+        cmd.append(command)
 
     cmd = " ".join(cmd)
 


### PR DESCRIPTION
Aims to resolve https://github.com/neoave/mrack/issues/98

After this patch:
```
2021-04-19 12:56:24,432 mrack.utils INFO ssh -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -l fedora -i config/id_rsa 10.0.99.34 echo mrack
2021-04-19 12:56:24,456 mrack.providers.provider INFO OpenStack: 1 hosts were not provisioned properly, deleting.
2021-04-19 12:56:24,457 mrack.providers.provider ERROR OpenStack: Error: Could not establish ssh connection to host d0160fba-803e-4ed8-bab4-4b42c248849d with IP 10.0.99.34
```