### PR TITLE
feat: Enable config drive in OpenStack

### DIFF
--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -58,6 +58,9 @@ openstack:  # OpenStack provider specific values
     # credentials profile to use from file
     profile: devstack
 
+    # Enable Config drive to fetch metadata from a mounted volume instead of Metadata Service
+    # enable_config_drive: True
+
 # default user per image from the any of provider configuration
 users:
     fedora-32: fedora

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -155,6 +155,7 @@ class OpenStackTransformer(Transformer):
             "image": required_image,
             "key_name": self.config["keypair"],
             "network": self._get_network_type(host),
+            "config_drive": self.config.get("enable_config_drive", False),
         }
 
     def create_host_requirements(self):


### PR DESCRIPTION
By default Nova's metadata informatation if retrieved via HTTP, setting `enable_config_drive` to True in provisioning-config will make metadata available via a config drive, a special drive that are attached to an instance when it boots.

This is helpful when connection is not stable during host booting stage, host would be unreachable because cloud-init is failing to injecting SSH keys into it.

This reduces the chance of hosts being provisioned but not accessible.

---

Raw data on `.mrack.db` shown that setting as "" (empty string). This behavior continues if `enable_config_drive` is False or not set.

From `/var/log/cloud-init.log` with Config Drive **disabled**:
```
 2021-04-19 17:59:19,445 - dhcp.py[DEBUG]: Received dhcp lease on eth0 for ************/255.255.252.0
2021-04-19 17:59:19,445 - __init__.py[DEBUG]: Attempting setup of ephemeral network on eth0 with **********/22 brd ********
2021-04-19 17:59:19,445 - util.py[DEBUG]: Running command ['ip', '-family', 'inet', 'addr', 'add', '**********/22', 'broadcast', '*********', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
2021-04-19 17:59:19,453 - util.py[DEBUG]: Running command ['ip', '-family', 'inet', 'link', 'set', 'dev', 'eth0', 'up'] with allowed return codes [0] (shell=False, capture=True)
2021-04-19 17:59:19,457 - util.py[DEBUG]: Running command ['ip', '-4', 'route', 'add', '169.254.169.254/32', 'via', '********', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
2021-04-19 17:59:19,461 - util.py[DEBUG]: Running command ['ip', '-4', 'route', 'add', '0.0.0.0/0', 'via', '************', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
2021-04-19 17:59:19,469 - util.py[DEBUG]: Resolving URL: http://169.254.169.254 took 0.005 seconds
2021-04-19 17:59:19,469 - url_helper.py[DEBUG]: [0/1] open 'http://169.254.169.254/openstack' with {'url': 'http://169.254.169.254/openstack', 'allow_redirects': True, 'method': 'GET', 'timeout': 10.0, 'headers': {'User-Agent': 'Cloud-Init/19.4'}} configuration
2021-04-19 17:59:20,236 - url_helper.py[DEBUG]: Read from http://169.254.169.254/openstack (200, 94b) after 1 attempts
2021-04-19 17:59:20,236 - DataSourceOpenStack.py[DEBUG]: Using metadata source: 'http://169.254.169.254'
2021-04-19 17:59:20,236 - url_helper.py[DEBUG]: [0/6] open 'http://169.254.169.254/openstack' with {'url': 'http://169.254.169.254/openstack', 'allow_redirects': True, 'method': 'GET', 'timeout': 10.0, 'headers': {'User-Agent': 'Cloud-Init/19.4'}} configuration
2021-04-19 17:59:20,787 - url_helper.py[DEBUG]: Read from http://169.254.169.254/openstack (200, 94b) after 1 attempts
2021-04-19 17:59:20,787 - openstack.py[DEBUG]: Selected version '2018-08-27' from ['2012-08-10', '2013-04-04', '2013-10-17', '2015-10-15', '2016-06-30', '2016-10-06', '2017-02-22', '2018-08-27', 'latest']
2021-04-19 17:59:20,788 - url_helper.py[DEBUG]: [0/6] open 'http://169.254.169.254/openstack/2018-08-27/meta_data.json' with {'url': 'http://169.254.169.254/openstack/2018-08-27/meta_data.json', 'allow_redirects': True, 'method': 'GET', 'timeout': 10.0, 'headers': {'User-Agent': 'Cloud-Init/19.4'}} configuration
```

From `/var/log/cloud-init.log` with Config Drive **enabled**:
```
2021-04-19 17:03:19,837 - util.py[DEBUG]: Running command ['mount', '-o', 'ro', '-t', 'auto', u'/dev/sr0', '/run/cloud-init/tmp/tmpuoIbjo'] with allowed return codes [0] (shell=False, capture=True)
2021-04-19 17:03:19,873 - openstack.py[DEBUG]: Selected version '2018-08-27' from ['2012-08-10', '2013-04-04', '2013-10-17', '2015-10-15', '2016-06-30', '2016-10-06', '2017-02-22', '2018-08-27', 'latest']
2021-04-19 17:03:19,874 - util.py[DEBUG]: Reading from /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/vendor_data.json (quiet=False)
2021-04-19 17:03:19,875 - util.py[DEBUG]: Read 2 bytes from /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/vendor_data.json
2021-04-19 17:03:19,875 - util.py[DEBUG]: Reading from /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/user_data (quiet=False)
2021-04-19 17:03:19,876 - openstack.py[DEBUG]: Failed reading optional path /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/user_data due to: [Errno 2] No such file or directory: '/run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/user_data'
2021-04-19 17:03:19,876 - util.py[DEBUG]: Reading from /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/network_data.json (quiet=False)
2021-04-19 17:03:19,876 - util.py[DEBUG]: Read 393 bytes from /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/network_data.json
2021-04-19 17:03:19,876 - util.py[DEBUG]: Reading from /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/meta_data.json (quiet=False)
2021-04-19 17:03:19,877 - util.py[DEBUG]: Read 1840 bytes from /run/cloud-init/tmp/tmpuoIbjo/openstack/2018-08-27/meta_data.json
2021-04-19 17:03:19,878 - util.py[DEBUG]: Reading from /run/cloud-init/tmp/tmpuoIbjo/ec2/latest/meta-data.json (quiet=False)
```