### PR TITLE
fix: ssh action crashes as it misses global_context

### DIFF
--- a/src/mrack/actions/ssh.py
+++ b/src/mrack/actions/ssh.py
@@ -19,6 +19,7 @@ import logging
 from mrack.errors import ApplicationError
 from mrack.host import STATUS_ACTIVE
 from mrack.providers.utils.podman import Podman
+from mrack.utils import global_context
 from mrack.utils import ssh_to_host as utils_ssh_to_host
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,9 @@ class SSH:
         self._config = config
         self._metadata = metadata
         self._db = db_driver
+
+        global_context["metadata"] = metadata
+        global_context["config"] = config
 
     def pick_host_interactively(self, hosts):
         """Print list of host and let user to choose one."""


### PR DESCRIPTION
utils.ssh_to_host requires to have global_context initialized but
with introduction of it ssh action was not ammended. Without it
mrack crashed on sshing to a host.

This fix is initializing utils.global_context in ssh_action and
thus fixing the issue.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>