### PR TITLE
feat: check ssh connectivity outside of pares_error_hosts more than once

### DIFF
--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -232,6 +232,7 @@ def ssh_to_host(
     if username:
         cmd.extend(["-l", username])
     if ssh_key:
+        cmd.extend(["-o", "'PasswordAuthentication=no'"])
         cmd.extend(["-i", ssh_key])
     psw_input = None
     if password and not ssh_key:


### PR DESCRIPTION
feat: check ssh connectivity outside of pares_error_hosts more than once

Move the ssh connectivity check outside of the
pares_error_hosts method to distinguish the functionality
and to be able to gather asynchronous results later.

Retry the ssh connection after if fails to not destroy
slower systems which may not have set up the proper
ssh key into allowed keys.
