### PR TITLE
feat: Use GlobalContext class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ![pypi_badge](https://img.shields.io/pypi/v/mrack?label=PyPI&logo=pypi) ![readthedocs_badge](https://img.shields.io/readthedocs/mrack?label=Read%20the%20Docs&logo=read-the-docs) ![badge](https://copr.fedorainfracloud.org/coprs/g/freeipa/neoave/package/mrack/status_image/last_build.png)
 
-**Important**: most of the described below is not implemented yet
-
 Provisioning library for CI and local multi-host testing supporting multiple
 provisioning providers e.g. OpenStack, libvirt, containers, Beaker).
 
@@ -114,13 +112,13 @@ all:
 
 ## Installation
 
-mrack can be installed via pip, from PyPI:
+mrack can be installed via pip, from [PyPI](https://pypi.org/project/mrack/):
 
 ```
 pip install mrack
 ```
 
-It is also available for Fedora 32+ via COPR:
+It is also available for Fedora 32+ via [COPR](https://copr.fedorainfracloud.org/coprs/g/freeipa/neoave/package/mrack/):
 
 ```
 sudo dnf copr enable @freeipa/neoave
@@ -164,7 +162,7 @@ To provision system from the metadata.yaml either run:
 ```
 mrack up
 ```
-or use `up` command's option `--metadata`/`-m` to orverride path to the metadata file.
+or use `up` command's option `--metadata`/`-m` to override path to the metadata file.
 ```
 mrack up --metadata other-metadata.yaml
 ```
@@ -173,7 +171,7 @@ To return resources using mrack run:
 ```
 mrack destroy
 ```
-or use `destroy` command's option `--metadata`/`-m` to orverride path to the metadata file.
+or use `destroy` command's option `--metadata`/`-m` to override path to the metadata file.
 ```
 mrack destroy --metadata other-metadata.yaml
 ```
@@ -181,8 +179,70 @@ mrack destroy --metadata other-metadata.yaml
 ### mrack as python library
 
 ```python
+# first set up authentication for each provider
+# $ export AWS_CONFIG_FILE=`readlink -f ./aws.key`
+from mrack.providers import providers
+# import all supported providers:
+from mrack.providers.aws import PROVISIONER_KEY as AWS
+from mrack.providers.aws import AWSProvider
+from mrack.providers.beaker import PROVISIONER_KEY as BEAKER
+from mrack.providers.beaker import BeakerProvider
+from mrack.providers.openstack import PROVISIONER_KEY as OPENSTACK
+from mrack.providers.openstack import OpenStackProvider
+from mrack.providers.podman import PROVISIONER_KEY as PODMAN
+from mrack.providers.podman import PodmanProvider
+from mrack.providers.static import PROVISIONER_KEY as STATIC
+from mrack.providers.static import StaticProvider
+from mrack.providers.virt import PROVISIONER_KEY as VIRT
+from mrack.providers.virt import VirtProvider
+
+# register all supported providers:
+providers.register(AWS, AWSProvider)
+providers.register(OPENSTACK, OpenStackProvider)
+providers.register(BEAKER, BeakerProvider)
+providers.register(PODMAN, PodmanProvider)
+providers.register(STATIC, StaticProvider)
+providers.register(VIRT, VirtProvider)
+
+
+# use global context class
 import mrack
-# TODO
+global_context = mrack.context.global_context
+
+# init global context with paths to files
+mrack_config = "mrack.conf"
+provisioning_config = "provisioning-config.yaml"
+db_file = "mrackdb.json"
+global_context.init(mrack_config, provisioning_config, db_file)
+
+# load the metadata to global_context
+metadata = "./metadata-f34.yaml"
+global_context.init_metadata(metadata)
+
+# pick default provider:
+provider = "aws"
+
+# create Up action
+
+from mrack.actions.up import Up
+
+up_action = Up()
+await up_action.init(provider)
+
+# provision machines:
+await up_action.provision()
+
+# store the output to db or just use the db later on
+from mrack.actions.output import Output
+output_action = Output()
+await output_action.generate_outputs()
+
+# work with machines...
+
+# cleanup the machines:
+from mrack.actions.destroy import Destroy
+destroy_action = Destroy()
+await destroy_action.destroy()
 ```
 
 ## Contribute
@@ -199,7 +259,7 @@ Please enable the feature on your local system and use it before sending a patch
 It could save us lot of re-pushing to the PR.
 
 ### Black formatting and isort
-Expected formatting can be achived by running:
+Expected formatting can be achieved by running:
 ```
 $ make format
 ```
@@ -212,6 +272,6 @@ Just run tox to execute all tests and linters
 
 ```
 $ tox
-# or us make
+# or use make
 $ make test
 ```

--- a/docs/guides/mrack_lib.rst
+++ b/docs/guides/mrack_lib.rst
@@ -1,0 +1,91 @@
+How to use mrack as library
+===========================
+
+mrack can be used as python library in automation and may provide fast provisioning
+of resources when needed.
+
+This short guide demonstrate how we can use mrack in python automation.
+
+First we should set up authentication for each provider in this example we will use aws.key file for boto3 library.
+.. code-block::
+
+    $ export AWS_CONFIG_FILE=`readlink -f /path/to/aws.key`
+
+We start to include all providers from mrack which we would like to use.
+.. code-block::
+
+    from mrack.providers import providers
+    from mrack.providers.aws import PROVISIONER_KEY as AWS
+    from mrack.providers.aws import AWSProvider
+    from mrack.providers.beaker import PROVISIONER_KEY as BEAKER
+    from mrack.providers.beaker import BeakerProvider
+    from mrack.providers.openstack import PROVISIONER_KEY as OPENSTACK
+    from mrack.providers.openstack import OpenStackProvider
+    from mrack.providers.podman import PROVISIONER_KEY as PODMAN
+    from mrack.providers.podman import PodmanProvider
+    from mrack.providers.static import PROVISIONER_KEY as STATIC
+    from mrack.providers.static import StaticProvider
+    from mrack.providers.virt import PROVISIONER_KEY as VIRT
+    from mrack.providers.virt import VirtProvider
+
+Then register all supported providers:
+.. code-block::
+
+    providers.register(AWS, AWSProvider)
+    providers.register(OPENSTACK, OpenStackProvider)
+    providers.register(BEAKER, BeakerProvider)
+    providers.register(PODMAN, PodmanProvider)
+    providers.register(STATIC, StaticProvider)
+    providers.register(VIRT, VirtProvider)
+
+Then register all supported providers:
+.. code-block::
+
+    import mrack
+    global_context = mrack.context.global_context
+
+After that we init global context with paths to files:
+.. code-block::
+
+    mrack_config = "mrack.conf"
+    provisioning_config = "provisioning-config.yaml"
+    db_file = "mrackdb.json"
+    global_context.init(mrack_config, provisioning_config, db_file)
+
+    # load the metadata to global_context
+    metadata = "./metadata-f34.yaml"
+    global_context.init_metadata(metadata)
+
+We pick default provider:
+.. code-block::
+
+    provider = "aws"
+
+
+Create Up action and provision machines:
+.. code-block::
+
+    from mrack.actions.up import Up
+
+    up_action = Up()
+    await up_action.init(provider)
+
+    # provision machines:
+    await up_action.provision()
+
+
+Create output action which handles DB saving:
+.. code-block::
+
+    # store the output to db or just use the db later on
+    from mrack.actions.output import Output
+    output_action = Output()
+    await output_action.generate_outputs()
+
+After successfully using our resources we cleanup machines by creating destroy action:
+.. code-block::
+
+    # cleanup the machines:
+    from mrack.actions.destroy import Destroy
+    destroy_action = Destroy()
+    await destroy_action.destroy()

--- a/src/mrack/actions/action.py
+++ b/src/mrack/actions/action.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Destroy action module."""
+
+import logging
+
+from mrack.context import global_context
+from mrack.errors import MetadataError
+from mrack.transformers import transformers
+
+logger = logging.getLogger(__name__)
+
+
+class Action:
+    """Base Action."""
+
+    def __init__(self, config=None, metadata=None, db_driver=None):
+        """Initialize the action."""
+        self._config = config or global_context.PROV_CONFIG
+        self._metadata = metadata or global_context.METADATA
+        self._db_driver = db_driver or global_context.DB
+        self._transformers = {}
+
+    async def _get_transformer(self, provider_name):
+        """Get a transformer by name, initialize a new one if not yet done."""
+        transformer = self._transformers.get(provider_name)
+        if not transformer:
+            transformer = transformers.get(provider_name)
+            await transformer.init(self._config, self._metadata)
+            if not transformer:
+                raise MetadataError(f"Invalid provider: {provider_name}")
+            self._transformers[provider_name] = transformer
+        return transformer
+
+
+class DBAction:
+    """Base Action."""
+
+    def __init__(
+        self,
+        db_driver=None,
+    ):
+        """Initialize the database action."""
+        self._db_driver = db_driver or global_context.DB

--- a/src/mrack/actions/destroy.py
+++ b/src/mrack/actions/destroy.py
@@ -17,25 +17,17 @@
 import asyncio
 import logging
 
-from mrack.errors import MetadataError
+from mrack.actions.action import Action
 from mrack.host import STATUS_DELETED
-from mrack.transformers import transformers
 
 logger = logging.getLogger(__name__)
 
 
-class Destroy:
+class Destroy(Action):
     """Destroy action.
 
     Destroy all still active provisioned host. Save the state to DB.
     """
-
-    async def init(self, config, metadata, db_driver):
-        """Initialize the destroy action."""
-        self._config = config
-        self._metadata = metadata
-        self._db_driver = db_driver
-        self._transformers = {}
 
     async def destroy(self):
         """Execute the destroy action."""
@@ -64,14 +56,3 @@ class Destroy:
         providers = set(providers)
         aws = [self._get_transformer(provider) for provider in providers]
         await asyncio.gather(*aws)
-
-    async def _get_transformer(self, provider_name):
-        """Get a transformer by name, initialize a new one if not yet done."""
-        transformer = self._transformers.get(provider_name)
-        if not transformer:
-            transformer = transformers.get(provider_name)
-            await transformer.init(self._config, self._metadata)
-            if not transformer:
-                raise MetadataError(f"Invalid provider: {provider_name}")
-            self._transformers[provider_name] = transformer
-        return transformer

--- a/src/mrack/actions/etchosts.py
+++ b/src/mrack/actions/etchosts.py
@@ -17,6 +17,7 @@
 import getpass
 import logging
 
+from mrack.actions.action import DBAction
 from mrack.errors import ApplicationError, ConfigError
 from mrack.host import STATUS_ACTIVE
 
@@ -118,12 +119,12 @@ class EtcHostsUpdater:
             raise ApplicationError(err) from perm_err
 
 
-class EtcHostsUpdate:
+class EtcHostsUpdate(DBAction):
     """Add active vms to /etc/hosts file."""
 
-    def __init__(self, db_driver):
+    def __init__(self, db_driver=None):
         """Initialize the /etc/hosts update action."""
-        self._db_driver = db_driver
+        super().__init__(db_driver=db_driver)
         self.updater = EtcHostsUpdater()
 
     def update(self):

--- a/src/mrack/actions/list.py
+++ b/src/mrack/actions/list.py
@@ -15,18 +15,16 @@
 """List action module."""
 import logging
 
+from mrack.actions.action import DBAction
+
 logger = logging.getLogger(__name__)
 
 
-class List:
+class List(DBAction):
     """List action.
 
     List hosts from DB.
     """
-
-    def init(self, db_driver):
-        """Initialize the List action."""
-        self._db_driver = db_driver
 
     def list(self):
         """Execute the List action."""

--- a/src/mrack/actions/output.py
+++ b/src/mrack/actions/output.py
@@ -15,6 +15,8 @@
 """Output action."""
 import logging
 
+from mrack.actions.action import Action
+from mrack.context import global_context
 from mrack.errors import MetadataError
 from mrack.outputs.ansible_inventory import AnsibleInventoryOutput
 from mrack.outputs.pytest_multihost import PytestMultihostOutput
@@ -22,22 +24,33 @@ from mrack.outputs.pytest_multihost import PytestMultihostOutput
 logger = logging.getLogger(__name__)
 
 
-class Output:
+class Output(Action):
     """
     Output action.
 
     Test action to run output modules from data in database.
     """
 
-    async def init(
-        self, config, metadata, db_driver, ansible_path, pytest_multihost_path
-    ):
+    def __init__(
+        self,
+        config=None,
+        metadata=None,
+        db_driver=None,
+        ansible_path=None,
+        pytest_multihost_path=None,
+    ):  # pylint: disable=arguments-differ
         """Initialize the Output action."""
-        self._config = config
-        self._metadata = metadata
-        self._db_driver = db_driver
-        self._ansible_path = ansible_path
-        self._pytest_multihost_path = pytest_multihost_path
+        super().__init__(config=config, metadata=metadata, db_driver=db_driver)
+
+        if global_context.CONFIG:
+            global_ansible_path = global_context.CONFIG.ansible_inventory_path()
+            global_multihost_path = global_context.CONFIG.pytest_multihost_path()
+        else:
+            global_ansible_path = None
+            global_multihost_path = None
+
+        self._ansible_path = ansible_path or global_ansible_path
+        self._pytest_multihost_path = pytest_multihost_path or global_multihost_path
 
     async def generate_outputs(self):
         """Generate outputs."""

--- a/src/mrack/context.py
+++ b/src/mrack/context.py
@@ -1,0 +1,94 @@
+# Copyright 2021 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Global mrack context object."""
+import os
+from typing import Dict
+
+from mrack.config import MrackConfig, ProvisioningConfig
+from mrack.dbdrivers.file import FileDBDriver
+from mrack.errors import ConfigError
+from mrack.utils import NoSuchFileHandler, load_yaml
+
+
+class GlobalContext:
+    """Global context class to store the mrack configuration."""
+
+    def __init__(self) -> None:
+        """Init empty GlobalContext class."""
+        self.database = None
+        self.mrack_conf = None
+        self.provisioning_config = None
+        self.metadata: Dict = {}
+
+    @property
+    def DB(self):  # pylint: disable=invalid-name
+        """Get FileDBDriver object."""
+        return self.database
+
+    @property
+    def CONFIG(self):  # pylint: disable=invalid-name
+        """Get MrackConfig object."""
+        return self.mrack_conf
+
+    @property
+    def PROV_CONFIG(self):  # pylint: disable=invalid-name
+        """Get ProvisioningConfig object."""
+        return self.provisioning_config
+
+    @property
+    def METADATA(self):  # pylint: disable=invalid-name
+        """Get ProvisioningConfig object."""
+        return self.metadata
+
+    def init(self, mrack_config, provisioning_config, db_file):
+        """Initialize Global Context object with all needed values."""
+        self._init_mrack_config(mrack_config)
+        self.mrack_conf.load()
+
+        db_path = db_file or self.mrack_conf.db_path(default="./.mrackdb.json")
+        p_config_path = provisioning_config or self.mrack_conf.provisioning_config_path(
+            default="./provisioning-config.yaml"
+        )
+
+        self._init_db(db_path)
+        self._init_prov_config(p_config_path)
+
+    def _init_db(self, path):
+        """Initialize file database."""
+        self.database = FileDBDriver(path)
+
+    @NoSuchFileHandler(error="Provisioning config file not found: {path}")
+    def _init_prov_config(self, path):
+        """Load and initialize provisioning configuration."""
+        self.provisioning_config = ProvisioningConfig(load_yaml(path))
+
+    def init_metadata(self, user_defined_path):
+        """Load and initialize job metadata."""
+        meta_path = user_defined_path or self.mrack_conf.metadata_path()
+
+        if not meta_path:
+            raise ConfigError("Job metadata file path not provided.")
+        if not os.path.exists(meta_path):
+            raise ConfigError(f"Job metadata file not found: {meta_path}")
+
+        self.metadata = load_yaml(meta_path)
+
+    def _init_mrack_config(self, mrack_config_path):
+        """Load and initialize mrack configuration."""
+        self.mrack_conf = MrackConfig(mrack_config_path)
+
+
+# Singleton context holder
+global_context = GlobalContext()

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -28,6 +28,7 @@ from bkr.client import BeakerJob, BeakerRecipe, BeakerRecipeSet
 from bkr.common.hub import HubProxy
 from bkr.common.pyconfig import PyConfigParser
 
+from mrack.context import global_context
 from mrack.errors import ProvisioningError, ValidationError
 from mrack.host import (
     STATUS_ACTIVE,
@@ -37,7 +38,6 @@ from mrack.host import (
     STATUS_PROVISIONING,
 )
 from mrack.providers.provider import STRATEGY_ABORT, Provider
-from mrack.utils import global_context
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +194,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         recipe.addDistroRequires(arch_node)
 
         # Specify the custom xml distro_tag node with values from provisioning config
-        distro_tags = global_context["config"]["beaker"].get("distro_tags")
+        distro_tags = global_context.PROV_CONFIG["beaker"].get("distro_tags")
         if distro_tags:
             for tag in distro_tags.get(specs["distro"], []):
                 tag_node = xml_doc().createElement("distro_tag")

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -108,8 +108,7 @@ def init_metadata(ctx, user_defined_path):
 async def generate_outputs(ctx):
     """Init and run output action."""
     config = ctx.obj[CONFIG]
-    output_action = Output()
-    await output_action.init(
+    output_action = Output(
         ctx.obj[PROV_CONFIG],
         ctx.obj[METADATA],
         ctx.obj[DB],
@@ -163,8 +162,8 @@ async def up(ctx, metadata, provider):  # pylint: disable=invalid-name
     """
     init_metadata(ctx, metadata)
 
-    up_action = Up()
-    await up_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], provider, ctx.obj[DB])
+    up_action = Up(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    await up_action.init(provider)
     await up_action.provision()
 
     await generate_outputs(ctx)
@@ -177,8 +176,7 @@ async def up(ctx, metadata, provider):  # pylint: disable=invalid-name
 async def destroy(ctx, metadata):
     """Destroy provisioned hosts."""
     init_metadata(ctx, metadata)
-    destroy_action = Destroy()
-    await destroy_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    destroy_action = Destroy(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     await destroy_action.destroy()
 
 
@@ -197,8 +195,7 @@ async def output(ctx, metadata):
 @async_run
 async def list(ctx):  # pylint: disable=redefined-builtin
     """List host tracked by."""
-    list_action = List()
-    list_action.init(ctx.obj[DB])
+    list_action = List(ctx.obj[DB])
     list_action.list()
 
 
@@ -210,8 +207,7 @@ async def list(ctx):  # pylint: disable=redefined-builtin
 async def ssh(ctx, hostname, metadata):
     """SSH to host."""
     init_metadata(ctx, metadata)
-    ssh_action = SSH()
-    ssh_action.init(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    ssh_action = SSH(ctx.obj[PROV_CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     return ssh_action.ssh(hostname)
 
 

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -22,13 +22,12 @@ class TestStaticProvider:
     async def test_up_action(
         self, provisioning_config, metadata, database, setup_providers
     ):
-        up_action = UpAction()
-        await up_action.init(
+        up_action = UpAction(
             config=provisioning_config,
             metadata=metadata,
-            default_provider="static",
             db_driver=database,
         )
+        await up_action.init(default_provider="static")
         await up_action.provision()
 
         assert database.hosts != {}
@@ -41,8 +40,7 @@ class TestStaticProvider:
 
     @pytest.mark.asyncio
     async def test_list_action(self, database, setup_providers, caplog):
-        list_action = ListAction()
-        list_action.init(
+        list_action = ListAction(
             db_driver=database,
         )
         list_action.list()
@@ -63,8 +61,7 @@ class TestStaticProvider:
         # Check that workdir is empty
         assert os.listdir(workdir) == []
 
-        output_action = OutputAction()
-        await output_action.init(
+        output_action = OutputAction(
             config=provisioning_config,
             metadata=metadata,
             db_driver=database,
@@ -82,8 +79,7 @@ class TestStaticProvider:
     async def test_destroy_action(
         self, provisioning_config, metadata, database, setup_providers
     ):
-        destroy_action = DestroyAction()
-        await destroy_action.init(
+        destroy_action = DestroyAction(
             config=provisioning_config,
             metadata=metadata,
             db_driver=database,


### PR DESCRIPTION
Use GlobalContext class in runtime
which allows us to use mrack with only this context
and as a library with only creating desired actions
Up/Destroy/... and calling them in python scripts.

some minor fixes are also included in this PR

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>