### PR TITLE
feat: Add --version option to mrack cli - alternative implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ version_source = "commit"
 commit_subject = "chore: Release version {version}"
 commit_message = "Releasing mrack version {version}"
 version_variable = [
-    "src/mrack/__init__.py:__version__",
-    "src/mrack/run.py:__version__",
+    "src/mrack/version.py:VERSION",
     "docs/conf.py:release",
 ]
 version_pattern = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ commit_subject = "chore: Release version {version}"
 commit_message = "Releasing mrack version {version}"
 version_variable = [
     "src/mrack/__init__.py:__version__",
+    "src/mrack/run.py:__version__",
     "docs/conf.py:release",
 ]
 version_pattern = [

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,8 @@ with open("README.md") as f:
 with open("requirements.txt") as req:
     reqs = req.readlines()
 
-with open("src/mrack/__init__.py", "r") as fd:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
-    )
+with open("src/mrack/version.py", "r") as fd:
+    version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE)
     if version is None:
         sys.stderr.write("Could not parse the version string.\n")
         sys.exit(1)

--- a/src/mrack/__init__.py
+++ b/src/mrack/__init__.py
@@ -1,5 +1,4 @@
 """mrack library."""
-__version__ = "0.10.0"
 
 import logging
 

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -14,6 +14,8 @@
 
 """mrack default app."""
 #  pylint: disable=no-name-in-module
+__version__ = "0.10.0"
+
 import asyncio
 import logging
 import os
@@ -126,6 +128,7 @@ METADATA = "metadata"
 @click.option("-p", "--provisioning-config", type=click.Path(exists=True))
 @click.option("-d", "--db", "db_file")  # db file may not exist
 @click.option("--debug", default=False, is_flag=True)
+@click.version_option(version=__version__)
 @click.pass_context
 def mrackcli(ctx, mrack_config, provisioning_config, db_file, debug):
     """Multihost human friendly provisioner."""

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -267,6 +267,7 @@ def exception_handler(func):
 @exception_handler
 def run():
     """Run the app."""
+    logger.debug(f"mrack version: {VERSION}")
     mrackcli(obj={})  # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
 
 

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -14,8 +14,6 @@
 
 """mrack default app."""
 #  pylint: disable=no-name-in-module
-__version__ = "0.10.0"
-
 import asyncio
 import logging
 import os
@@ -51,6 +49,7 @@ from mrack.providers.podman import PodmanProvider
 from mrack.providers.static import PROVISIONER_KEY as STATIC
 from mrack.providers.static import StaticProvider
 from mrack.utils import NoSuchFileHandler, load_yaml
+from mrack.version import VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +127,7 @@ METADATA = "metadata"
 @click.option("-p", "--provisioning-config", type=click.Path(exists=True))
 @click.option("-d", "--db", "db_file")  # db file may not exist
 @click.option("--debug", default=False, is_flag=True)
-@click.version_option(version=__version__)
+@click.version_option(version=VERSION)
 @click.pass_context
 def mrackcli(ctx, mrack_config, provisioning_config, db_file, debug):
     """Multihost human friendly provisioner."""

--- a/src/mrack/version.py
+++ b/src/mrack/version.py
@@ -1,0 +1,2 @@
+"""mrack library version."""
+VERSION = "0.10.0"


### PR DESCRIPTION
From my PoV, this is cleaner as there is version only on one location in the mrack package and it can be even more easily imported anywhere else. 

The second commit is also logging the version into mrack.log so that it is usable in debugging.

Alternative to: https://github.com/neoave/mrack/pull/109 