### PR TITLE
feat: move network translation to provider and remove redundant validation

### DIFF
--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -204,6 +204,7 @@ class Provider:
         missing_reqs = [
             req for req in reqs if req["name"] in [host.name for host in error_hosts]
         ]
+
         return (success_hosts, error_hosts, missing_reqs)
 
     async def provision_hosts(self, reqs):

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -224,9 +224,6 @@ class Provider:
         logger.info(f"{self.dsp_name}: Preparing provider resources")
         await self.prepare_provisioning(reqs)
 
-        logger.info(f"{self.dsp_name}: Validating hosts definitions")
-        await self.validate_hosts(reqs)
-
         if self.strategy == STRATEGY_RETRY:
             success_hosts, error_hosts, _missing_reqs = await self.strategy_retry(reqs)
         else:


### PR DESCRIPTION
Moving network translation to provider will help us 
to find new network for openstack VM when there
is a problem with network pools (insufficient ips)
that will help to choose another pool within openstack.

Transformer now only informs about network type
provider picks the network at every provision retry.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>