### PR TITLE
feat: Check and wait for resources when provisiong

### DIFF
--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -137,7 +137,7 @@ class AWSProvider(Provider):
 
         ids = [srv.id for srv in aws_res]
         if len(ids) != 1:  # ids must be len of 1 as we provision one vm at the time
-            raise ProvisioningError("Unexpected number of instances provisioned.")
+            raise ProvisioningError("Unexpected number of instances provisioned.", req)
         # creating name for instance (visible in aws ec2 WebUI)
         taglist = [{"Key": "name", "Value": specs.get("name")}]
         for key in self.instance_tags:

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -553,7 +553,8 @@ class OpenStackProvider(Provider):
             if error_attempts > SERVER_ERROR_RETRY:
                 # now we are past to what we would like to wait fail now
                 raise ProvisioningError(
-                    f"{self.dsp_name}: Failed to create server {object2json(specs)}"
+                    f"{self.dsp_name}: Failed to create server {req['name']}",
+                    req,  # add the requirement dictionary to traceback for later
                 )
 
             fault = response["server"].get("fault", {})

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -126,7 +126,9 @@ class PodmanProvider(Provider):
             logger.error(
                 f"{self.dsp_name}: Failed to load network requirement from: {req}"
             )
-            raise ProvisioningError("Could not set up podman network for some host(s)")
+            raise ProvisioningError(
+                "Could not set up podman network for some host(s)", req
+            )
 
         container_id = await self.podman.run(
             image,

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -212,10 +212,7 @@ class Provider:
 
         Main provider method for provisioning.
 
-        First it validates that host requirements are valid and that
-        provider has enough resources(quota).
-
-        Then issues provisioning and waits for it succeed. Raises exception if any of
+        Issues provisioning and waits for it succeed. Raises exception if any of
         the servers was not successfully provisioned. If that happens it issues deletion
         of all already provisioned resources.
 


### PR DESCRIPTION
feat: Wait for provider resources up to hour

Checking resources more than once should help
to provide better results when we are facing
the providers to be overocupied.



feat(OpenStack): Check openstack response for resources issue

OpenStack may be oversubscribed so even when we do not reach
our quota limit provisioning may fail due to lack of resources.
In such scenario (OpenStack run out of hosts to provision)
we check the response from server and act based on the fact
that OpenStack itself is being fully loaded and does not have
free resources to provide for our server.


docs: Update method docsting as it does not Validate hosts anymore

feat: gracefully destroy servers after traceback

This allows us to create dummy Host object based
on the ProvisioningError traceback arguments
where we added also requirement which may have
caused the provisioning to fail so the worflow
can continue and remove already provisioned
servers after reprovision / abort strategy is
done so resources that may not be freed
to openstack will be returned.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>
