### PR TITLE
feat(Beaker): Add distro tag from provisioning conf

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -36,6 +36,7 @@ from mrack.host import (
     STATUS_PROVISIONING,
 )
 from mrack.providers.provider import STRATEGY_ABORT, Provider
+from mrack.utils import global_context
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +155,15 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         arch_node.setAttribute("op", "=")
         arch_node.setAttribute("value", specs["arch"])
         recipe.addDistroRequires(arch_node)
+
+        # Specify the custom xml distro_tag node with values from provisioning config
+        distro_tags = global_context["config"]["beaker"].get("distro_tags")
+        if distro_tags:
+            for tag in distro_tags.get(specs["distro"], []):
+                tag_node = xml_doc().createElement("distro_tag")
+                tag_node.setAttribute("op", "=")
+                tag_node.setAttribute("value", tag)
+                recipe.addDistroRequires(tag_node)
 
         # Add ReserveSys element to reserve system after provisioning
         recipe.addReservesys(duration=str(self.reserve_duration))


### PR DESCRIPTION
Add feature which enables adding distro tags specified
in the provisioning config in beaker section like:
```
beaker:
    distro_tags:
        FEDORA-34%:
            - NIGHTLY-TESTED
```
This allows us to specify distros with custom tags.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>