### PR TITLE
feat:  Update providers to have configurable strategy and minor fixes

### DIFF
--- a/docs/guides/credentials.rst
+++ b/docs/guides/credentials.rst
@@ -46,17 +46,19 @@ set ``client_conf`` pointing to your Beaker client configuration. E.g:
 
 .. code:: yaml
 
-   beaker:
-       distros:
-           fedora-33: Fedora-33%
-           fedora-32: Fedora-32%
+    beaker:
+        strategy: retry
+        max_retry: 3
+        distros:
+            fedora-33: Fedora-33%
+            fedora-32: Fedora-32%
 
-       client_conf: /etc/beaker/client.conf
-       keypair: id_rsa.pub
+        client_conf: /etc/beaker/client.conf
+        keypair: id_rsa.pub
 
-       reserve_duration: 86400
-       server_role: idm_ci_bkr_server
-       max_attempts: 240
+        reserve_duration: 86400
+        server_role: idm_ci_bkr_server
+        timeout: 240
 
 More info about Beaker client configuration is available `here <https://beaker-project.org/docs/user-guide/bkr-client.html>`__
 
@@ -88,14 +90,15 @@ Provisioning config enablement:
 .. code:: yaml
 
     virt:
-    images:
-        fedora-32: https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
-        fedora-33: https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2
-    options: # defaults for undefined groups
-        ram: 1024 # in MiB
-        disksize: 10 # in GiB
-    groups: # per-group overrides, similar to flavors
-        ipaserver:
-            ram: 2560
-        ad:
-            ram: 3072
+        strategy: abort
+        images:
+            fedora-32: https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+            fedora-33: https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2
+        options: # defaults for undefined groups
+            ram: 1024 # in MiB
+            disksize: 10 # in GiB
+        groups: # per-group overrides, similar to flavors
+            ipaserver:
+                ram: 2560
+            ad:
+                ram: 3072

--- a/docs/guides/strategy.rst
+++ b/docs/guides/strategy.rst
@@ -1,0 +1,21 @@
+How to configure provider's provisioning strategy
+=======================================
+
+mrack supports several providers and each provider can be configured to retry
+the provisioning of resource when needed.
+By default mrack's strategy is to abort the process of providing resources and fail.
+
+This short guide explains how we can configure each provider to retry provisioning on any failure.
+After reaching `max_retry` count mrack will fail as it could not provide required VMs in desired attempts count.
+
+Provisioning config enablement:
+
+.. code:: yaml
+
+    aws|beaker|openstack|pomdan|virt:
+        # feature to switch provisioning strategy from abort or retry on fail
+        strategy: retry # use either `abort` or `retry`
+        # maximum count of the retries when re-provisioning resources
+        # fails if retry does not provide resource after max_retry count
+        max_retry: 3
+        ...

--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -76,8 +76,8 @@ beaker:  # beaker provider specific values
     pubkey: id_rsa.pub
     # default reservation time for the beaker job
     reserve_duration: 86400
-    # default max_attepmts value for the beaker job
-    max_attempts: 240
+    # default timeout value for the beaker job in minutes
+    timeout: 120
 
 
 openstack:  # OpenStack provider specific values

--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -1,5 +1,8 @@
 ---
 podman:
+    # feature to switch provisioning strategy from abort or retry on fail
+    strategy: abort
+
     images:
         # example: systemd enabled container images from: https://github.com/Tiboris/snappeas
         fedora-rawhide: tdudlak/snappeas:fedora-rawhide
@@ -68,6 +71,12 @@ aws:  # aws provider config
 
 
 beaker:  # beaker provider specific values
+    # feature to switch provisioning strategy from abort or retry on fail
+    strategy: retry
+    # maximum count of the retries when re-provisioning resources
+    # fails if retry does not provide resource after max_retry count
+    max_retry: 3
+
     distros:
         # list of beaker distros key is used in metadata distro is used in generated jobxml
         fedora-32: Fedora-32%
@@ -81,6 +90,12 @@ beaker:  # beaker provider specific values
 
 
 openstack:  # OpenStack provider specific values
+    # feature to switch provisioning strategy from abort or retry on fail
+    strategy: retry
+    # maximum count of the retries when re-provisioning resources
+    # fails if retry does not provide resource after max_retry count
+    max_retry: 5
+
     images:
         fedora-32: Fedora-Cloud-Base-32-latest
 

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -42,6 +42,7 @@ class AWSProvider(Provider):
         self.ssh_key = None
         self.sec_group = None
         self.instance_tags = None
+        self.max_attempts = 3 # for retry strategy
         self.status_map = {
             "running": STATUS_ACTIVE,
             "pending": STATUS_PROVISIONING,

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -38,7 +38,6 @@ class AWSProvider(Provider):
         """Object initialization."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "AWS"
-        self.strategy = STRATEGY_ABORT
         self.ami_ids: typing.List[str] = []
         self.ssh_key = None
         self.sec_group = None
@@ -57,20 +56,23 @@ class AWSProvider(Provider):
         """Get provider name."""
         return self._name
 
-    async def init(self, ami_ids, ssh_key, sec_group, instance_tags):
+    async def init(
+        self, ami_ids, ssh_key, sec_group, instance_tags, strategy=STRATEGY_ABORT
+    ):
         """Initialize provider with data from AWS."""
         # AWS_CONFIG_FILE=`readlink -f ./aws.key`
         logger.info(f"{self.dsp_name}: Initializing provider")
         login_start = datetime.now()
+        self.strategy = strategy
         self.ec2 = boto3.resource("ec2")
         self.client = boto3.client("ec2")
-        login_end = datetime.now()
-        login_duration = login_end - login_start
-        logger.info(f"{self.dsp_name}: Login duration {login_duration}")
         self.ami_ids = ami_ids
         self.ssh_key = ssh_key
         self.sec_group = sec_group
         self.instance_tags = instance_tags
+        login_end = datetime.now()
+        login_duration = login_end - login_start
+        logger.info(f"{self.dsp_name}: Login duration {login_duration}")
 
     async def prepare_provisioning(self, reqs):
         """Prepare provisioning."""

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -42,7 +42,7 @@ class AWSProvider(Provider):
         self.ssh_key = None
         self.sec_group = None
         self.instance_tags = None
-        self.max_attempts = 3 # for retry strategy
+        self.max_retry = 1  # for retry strategy
         self.status_map = {
             "running": STATUS_ACTIVE,
             "pending": STATUS_PROVISIONING,
@@ -58,13 +58,20 @@ class AWSProvider(Provider):
         return self._name
 
     async def init(
-        self, ami_ids, ssh_key, sec_group, instance_tags, strategy=STRATEGY_ABORT
+        self,
+        ami_ids,
+        ssh_key,
+        sec_group,
+        instance_tags,
+        strategy=STRATEGY_ABORT,
+        max_retry=1,
     ):
         """Initialize provider with data from AWS."""
         # AWS_CONFIG_FILE=`readlink -f ./aws.key`
         logger.info(f"{self.dsp_name}: Initializing provider")
         login_start = datetime.now()
         self.strategy = strategy
+        self.max_retry = max_retry
         self.ec2 = boto3.resource("ec2")
         self.client = boto3.client("ec2")
         self.ami_ids = ami_ids

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -255,8 +255,9 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
 
             if prev_status != status:
                 logger.info(
-                    f"{self.dsp_name}: Job {beaker_id} has changed "
-                    f"status ({prev_status} -> {status})"
+                    f"{self.dsp_name}: Job "
+                    f"{self.hub._hub_url}jobs/"  # pylint: disable=protected-access
+                    f"{resource['id']} has changed status ({prev_status} -> {status})"
                 )
                 prev_status = status
 
@@ -266,14 +267,18 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
                 break
             elif self.status_map.get(status) in [STATUS_ERROR, STATUS_DELETED]:
                 logger.warning(
-                    f"{self.dsp_name}: Job {beaker_id} has errored with status "
-                    f"{status} and result {resource['result']}"
+                    f"{self.dsp_name}: Job "
+                    f"{self.hub._hub_url}"  # pylint: disable=protected-access
+                    f"jobs/{resource['id']} has errored with status"
+                    f" {status} and result {resource['result']}"
                 )
                 break
             else:
                 logger.error(
-                    f"{self.dsp_name}: Job {beaker_id} has switched to unexpected "
-                    f"status {status} with result {resource['result']}"
+                    f"{self.dsp_name}: Job "
+                    f"{self.hub._hub_url}"  # pylint: disable=protected-access
+                    f"jobs/{resource['id']} has switched to unexpected"
+                    f" status {status} with result {resource['result']}"
                 )
                 break
 
@@ -292,7 +297,11 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
 
     async def delete_host(self, host_id):
         """Delete provisioned hosts based on input from provision_hosts."""
-        logger.info(f"{self.dsp_name}: Deleting host by cancelling Job {host_id}")
+        logger.info(
+            f"{self.dsp_name}: Deleting host by cancelling Job "
+            f"{self.hub._hub_url}"  # pylint: disable=protected-access
+            f"jobs/{host_id.split(':')[1]}"
+        )
         return self.hub.taskactions.stop(
             host_id, "cancel", "Job has been stopped by mrack."
         )

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -53,6 +53,7 @@ class BeakerProvider(Provider):
         self.conf = PyConfigParser()
         self.poll_sleep = 30  # seconds
         self.pubkey = None
+        self.max_attempts = 3 # for retry strategy
         self.status_map = {
             "Reserved": STATUS_ACTIVE,
             "New": STATUS_PROVISIONING,
@@ -69,14 +70,13 @@ class BeakerProvider(Provider):
         }
 
     async def init(
-        self, distros, max_attempts, reserve_duration, pubkey, strategy=STRATEGY_ABORT
+        self, distros, timeout, reserve_duration, pubkey, strategy=STRATEGY_ABORT
     ):
         """Initialize provider with data from Beaker configuration."""
         logger.info(f"{self.dsp_name}: Initializing provider")
         self.strategy = strategy
         self.distros = distros
-        # eg: 240 attempts * 30s timeout - 2h timeout for job to complete
-        self.max_attempts = max_attempts
+        self.timeout = timeout
         self.reserve_duration = reserve_duration
         self.pubkey = pubkey
         login_start = datetime.now()

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -272,7 +272,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
                 break
             else:
                 logger.error(
-                    f"{self.dsp_name}: Job {beaker_id} has swithced to unexpected "
+                    f"{self.dsp_name}: Job {beaker_id} has switched to unexpected "
                     f"status {status} with result {resource['result']}"
                 )
                 break

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -61,7 +61,7 @@ class OpenStackProvider(Provider):
         """Object initialization."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "OpenStack"
-        self.max_attempts = 5  # provisioning retries
+        self.max_retry = 1  # provisioning retries
         self.flavors = {}
         self.flavors_by_ref = {}
         self.images = {}
@@ -86,7 +86,9 @@ class OpenStackProvider(Provider):
             # https://docs.openstack.org/api-guide/compute/server_concepts.html
         }
 
-    async def init(self, image_names=None, networks=None, strategy=STRATEGY_ABORT):
+    async def init(
+        self, image_names=None, networks=None, strategy=STRATEGY_ABORT, max_retry=1
+    ):
         """Initialize provider with data from OpenStack.
 
         Load:
@@ -99,6 +101,7 @@ class OpenStackProvider(Provider):
         # session expects that credentials will be set via env variables
         logger.info(f"{self.dsp_name}: Initializing provider")
         self.strategy = strategy
+        self.max_retry = max_retry
         try:
             self.session = AuthPassword()
         except TypeError as terr:

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -32,7 +32,7 @@ from mrack.errors import (
     ValidationError,
 )
 from mrack.host import STATUS_ACTIVE, STATUS_DELETED, STATUS_ERROR, STATUS_PROVISIONING
-from mrack.providers.provider import STRATEGY_RETRY, Provider
+from mrack.providers.provider import STRATEGY_ABORT, Provider
 from mrack.providers.utils.osapi import ExtraNovaClient, NeutronClient
 from mrack.utils import object2json
 
@@ -61,7 +61,6 @@ class OpenStackProvider(Provider):
         """Object initialization."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "OpenStack"
-        self.strategy = STRATEGY_RETRY
         self.max_attempts = 5  # provisioning retries
         self.flavors = {}
         self.flavors_by_ref = {}
@@ -87,7 +86,7 @@ class OpenStackProvider(Provider):
             # https://docs.openstack.org/api-guide/compute/server_concepts.html
         }
 
-    async def init(self, image_names=None, networks=None):
+    async def init(self, image_names=None, networks=None, strategy=STRATEGY_ABORT):
         """Initialize provider with data from OpenStack.
 
         Load:
@@ -99,6 +98,7 @@ class OpenStackProvider(Provider):
         """
         # session expects that credentials will be set via env variables
         logger.info(f"{self.dsp_name}: Initializing provider")
+        self.strategy = strategy
         try:
             self.session = AuthPassword()
         except TypeError as terr:

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -37,7 +37,6 @@ class PodmanProvider(Provider):
         """Initialize provider."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "Podman"
-        self.strategy = STRATEGY_ABORT
         self.podman = Podman()
         self.status_map = {
             STATUS_ACTIVE: STATUS_ACTIVE,
@@ -45,10 +44,18 @@ class PodmanProvider(Provider):
             STATUS_ERROR: STATUS_ERROR,
         }
 
-    async def init(self, container_images, default_network, ssh_key, container_options):
+    async def init(
+        self,
+        container_images,
+        default_network,
+        ssh_key,
+        container_options,
+        strategy=STRATEGY_ABORT,
+    ):
         """Initialize Podman provider with data from config."""
         logger.info(f"{self.dsp_name}: Initializing provider")
         login_start = datetime.now()
+        self.strategy = strategy
         self.images = container_images
         self.default_network = default_network
         self.ssh_key = ssh_key

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -37,6 +37,7 @@ class PodmanProvider(Provider):
         """Initialize provider."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "Podman"
+        self.max_attempts = 1 # for retry strategy
         self.podman = Podman()
         self.status_map = {
             STATUS_ACTIVE: STATUS_ACTIVE,

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -37,7 +37,7 @@ class PodmanProvider(Provider):
         """Initialize provider."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "Podman"
-        self.max_attempts = 1 # for retry strategy
+        self.max_retry = 1  # for retry strategy
         self.podman = Podman()
         self.status_map = {
             STATUS_ACTIVE: STATUS_ACTIVE,

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -292,7 +292,11 @@ class Provider:
             )
             success_hosts.extend(s_hosts)
 
-            if error_hosts:
+            # We need to cleanup the error hosts for the next retry run
+            # in case of last attempt which is `self.max_retry`
+            # we skip this part at it done in provision_hosts() method while
+            # awaiting the self.abort_and_delete(error hosts)
+            if error_hosts and attempts != self.max_retry:
                 count = len(error_hosts)
                 err = f"{count} hosts were not provisioned properly, deleting."
                 logger.info(f"{self.dsp_name}: {err}")

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -39,7 +39,7 @@ class Provider:
         """Initialize provider."""
         self._name = "dummy"
         self.dsp_name = "Dummy"
-        self.max_attempts = 1
+        self.max_retry = 1
         self.strategy = STRATEGY_ABORT
         self.status_map = {"OTHER": STATUS_OTHER}
 
@@ -280,8 +280,10 @@ class Provider:
         error_hosts = []
 
         while missing_reqs:
-            if attempts >= self.max_attempts:
-                logger.error(f"Max attempts({self.max_attempts}) reached. Aborting.")
+            if attempts >= self.max_retry:
+                logger.error(
+                    f"{self.dsp_name}: Max attempts({self.max_retry}) reached. Aborting"
+                )
                 break
 
             attempts += 1
@@ -297,7 +299,7 @@ class Provider:
                 for host in error_hosts:
                     logger.error(f"{self.dsp_name}: Error: {str(host.error)}")
                 await self.delete_hosts(error_hosts)
-                logger.info("Retrying to provision these hosts.")
+                logger.info(f"{self.dsp_name}: Retrying to provision these hosts.")
 
         return success_hosts, error_hosts, missing_reqs
 

--- a/src/mrack/providers/static.py
+++ b/src/mrack/providers/static.py
@@ -32,7 +32,7 @@ class StaticProvider(Provider):
     def __init__(self):
         """Object initialization."""
         self._name = PROVISIONER_KEY
-        self.max_attempts = 1 # for retry strategy
+        self.max_retry = 1  # for retry strategy
         self.strategy = STRATEGY_ABORT
         self.status_map = {STATUS_ACTIVE: STATUS_ACTIVE}
 

--- a/src/mrack/providers/static.py
+++ b/src/mrack/providers/static.py
@@ -32,6 +32,7 @@ class StaticProvider(Provider):
     def __init__(self):
         """Object initialization."""
         self._name = PROVISIONER_KEY
+        self.max_attempts = 1 # for retry strategy
         self.strategy = STRATEGY_ABORT
         self.status_map = {STATUS_ACTIVE: STATUS_ACTIVE}
 

--- a/src/mrack/providers/virt.py
+++ b/src/mrack/providers/virt.py
@@ -39,6 +39,7 @@ class VirtProvider(Provider):
         self._name = PROVISIONER_KEY
         self.dsp_name = "Virt"
         self.testcloud = Testcloud()
+        self.max_attempts = 1 # for retry strategy
         self.status_map = {
             "running": STATUS_ACTIVE,
             "shutoff": STATUS_OTHER,

--- a/src/mrack/providers/virt.py
+++ b/src/mrack/providers/virt.py
@@ -38,7 +38,6 @@ class VirtProvider(Provider):
         """Initialize provider."""
         self._name = PROVISIONER_KEY
         self.dsp_name = "Virt"
-        self.strategy = STRATEGY_ABORT
         self.testcloud = Testcloud()
         self.status_map = {
             "running": STATUS_ACTIVE,
@@ -46,10 +45,11 @@ class VirtProvider(Provider):
             "undefined": STATUS_OTHER,
         }
 
-    async def init(self):
+    async def init(self, strategy=STRATEGY_ABORT):
         """Initialize Virt provider with data from config."""
         logger.info(f"{self.dsp_name}: Initializing provider")
         login_start = datetime.now()
+        self.strategy = strategy
         login_end = datetime.now()
         login_duration = login_end - login_start
         logger.info(f"{self.dsp_name}: Init duration {login_duration}")

--- a/src/mrack/providers/virt.py
+++ b/src/mrack/providers/virt.py
@@ -39,18 +39,19 @@ class VirtProvider(Provider):
         self._name = PROVISIONER_KEY
         self.dsp_name = "Virt"
         self.testcloud = Testcloud()
-        self.max_attempts = 1 # for retry strategy
+        self.max_retry = 1  # for retry strategy
         self.status_map = {
             "running": STATUS_ACTIVE,
             "shutoff": STATUS_OTHER,
             "undefined": STATUS_OTHER,
         }
 
-    async def init(self, strategy=STRATEGY_ABORT):
+    async def init(self, strategy=STRATEGY_ABORT, max_retry=1):
         """Initialize Virt provider with data from config."""
         logger.info(f"{self.dsp_name}: Initializing provider")
         login_start = datetime.now()
         self.strategy = strategy
+        self.max_retry = max_retry
         login_end = datetime.now()
         login_duration = login_end - login_start
         logger.info(f"{self.dsp_name}: Init duration {login_duration}")

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -14,6 +14,7 @@
 
 """AWS transformer module."""
 
+from mrack.providers.provider import STRATEGY_ABORT
 from mrack.transformers.transformer import Transformer
 
 CONFIG_KEY = "aws"
@@ -41,6 +42,7 @@ class AWSTransformer(Transformer):
             ssh_key=self.config["keypair"],
             sec_group=self.config["security_group"],
             instance_tags=self.config["instance_tags"],
+            strategy=self.config.get("strategy", STRATEGY_ABORT),
         )
 
     def create_host_requirement(self, host):

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -15,7 +15,7 @@
 """AWS transformer module."""
 
 from mrack.providers.provider import STRATEGY_ABORT
-from mrack.transformers.transformer import Transformer
+from mrack.transformers.transformer import DEFAULT_ATTEMPTS, Transformer
 
 CONFIG_KEY = "aws"
 
@@ -43,6 +43,7 @@ class AWSTransformer(Transformer):
             sec_group=self.config["security_group"],
             instance_tags=self.config["instance_tags"],
             strategy=self.config.get("strategy", STRATEGY_ABORT),
+            max_retry=self.config.get("max_retry", DEFAULT_ATTEMPTS),
         )
 
     def create_host_requirement(self, host):

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -15,6 +15,7 @@
 """Beaker transformer module."""
 import re
 
+from mrack.providers.provider import STRATEGY_ABORT
 from mrack.transformers.transformer import Transformer
 
 CONFIG_KEY = "beaker"
@@ -39,6 +40,7 @@ class BeakerTransformer(Transformer):
             max_attempts=self.config["max_attempts"],
             reserve_duration=self.config["reserve_duration"],
             pubkey=self.config["pubkey"],
+            strategy=self.config.get("strategy", STRATEGY_ABORT),
         )
 
     def _get_bkr_variant(self, host):

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -29,7 +29,7 @@ class BeakerTransformer(Transformer):
         "distros",
         "pubkey",
         "reserve_duration",
-        "max_attempts",
+        "timeout",
     ]  # List[str]
 
     async def init_provider(self):
@@ -37,7 +37,7 @@ class BeakerTransformer(Transformer):
         self.dsp_name = "Beaker"
         await self._provider.init(
             distros=self.config["distros"].values(),
-            max_attempts=self.config["max_attempts"],
+            timeout=self.config["timeout"],
             reserve_duration=self.config["reserve_duration"],
             pubkey=self.config["pubkey"],
             strategy=self.config.get("strategy", STRATEGY_ABORT),

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -19,6 +19,7 @@ from mrack.providers.provider import STRATEGY_ABORT
 from mrack.transformers.transformer import Transformer
 
 CONFIG_KEY = "beaker"
+DEFAULT_ATTEMPTS = 2
 
 
 class BeakerTransformer(Transformer):
@@ -41,6 +42,7 @@ class BeakerTransformer(Transformer):
             reserve_duration=self.config["reserve_duration"],
             pubkey=self.config["pubkey"],
             strategy=self.config.get("strategy", STRATEGY_ABORT),
+            max_retry=self.config.get("max_retry", DEFAULT_ATTEMPTS),
         )
 
     def _get_bkr_variant(self, host):

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -16,6 +16,7 @@
 import logging
 
 from mrack.errors import ProvisioningConfigError
+from mrack.providers.provider import STRATEGY_ABORT
 from mrack.transformers.transformer import Transformer
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class OpenStackTransformer(Transformer):
         await self._provider.init(
             image_names=self.config["images"].values(),
             networks=self.config["networks"],
+            strategy=self.config.get("strategy", STRATEGY_ABORT),
         )
 
     def _get_network_type(self, host):

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -22,6 +22,7 @@ from mrack.transformers.transformer import Transformer
 logger = logging.getLogger(__name__)
 
 CONFIG_KEY = "openstack"
+DEFAULT_ATTEMPTS = 5
 
 
 class OpenStackTransformer(Transformer):
@@ -37,6 +38,7 @@ class OpenStackTransformer(Transformer):
             image_names=self.config["images"].values(),
             networks=self.config["networks"],
             strategy=self.config.get("strategy", STRATEGY_ABORT),
+            max_retry=self.config.get("max_retry", DEFAULT_ATTEMPTS),
         )
 
     def _get_network_type(self, host):

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -14,6 +14,7 @@
 
 """Podman transformer module."""
 
+from mrack.providers.provider import STRATEGY_ABORT
 from mrack.transformers.transformer import Transformer
 from mrack.utils import get_host_from_metadata
 
@@ -40,6 +41,7 @@ class PodmanTransformer(Transformer):
             ssh_key=self.config["pubkey"],
             default_network=self.config["default_network"],
             container_options=self.config["podman_options"],
+            strategy=self.config.get("strategy", STRATEGY_ABORT),
         )
 
     def create_host_requirement(self, host):

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -15,7 +15,7 @@
 """Podman transformer module."""
 
 from mrack.providers.provider import STRATEGY_ABORT
-from mrack.transformers.transformer import Transformer
+from mrack.transformers.transformer import DEFAULT_ATTEMPTS, Transformer
 from mrack.utils import get_host_from_metadata
 
 CONFIG_KEY = "podman"
@@ -42,6 +42,7 @@ class PodmanTransformer(Transformer):
             default_network=self.config["default_network"],
             container_options=self.config["podman_options"],
             strategy=self.config.get("strategy", STRATEGY_ABORT),
+            max_retry=self.config.get("max_retry", DEFAULT_ATTEMPTS),
         )
 
     def create_host_requirement(self, host):

--- a/src/mrack/transformers/static.py
+++ b/src/mrack/transformers/static.py
@@ -32,10 +32,6 @@ class StaticTransformer(Transformer):
     _required_config_attrs: typing.List[str] = []
     _required_host_attrs = ["name", "os", "group", "ip"]
 
-    async def init_provider(self):
-        """Initialize associate provider."""
-        pass
-
     def create_host_requirement(self, host):
         """Create single input for Static provisioner."""
         return deepcopy(host)

--- a/src/mrack/transformers/transformer.py
+++ b/src/mrack/transformers/transformer.py
@@ -21,6 +21,8 @@ from mrack.errors import ConfigError, MetadataError
 from mrack.providers import providers
 from mrack.utils import get_config_value, object2json, validate_dict_attrs
 
+DEFAULT_ATTEMPTS = 1
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/mrack/transformers/virt.py
+++ b/src/mrack/transformers/virt.py
@@ -16,6 +16,7 @@
 
 import secrets
 
+from mrack.providers.provider import STRATEGY_ABORT
 from mrack.transformers.transformer import Transformer
 
 CONFIG_KEY = "virt"
@@ -34,7 +35,9 @@ class VirtTransformer(Transformer):
     async def init_provider(self):
         """Initialize associate provider and transformer display name."""
         self.dsp_name = "Virt"
-        await self._provider.init()
+        await self._provider.init(
+            strategy=self.config.get("strategy", STRATEGY_ABORT),
+        )
 
     def _get_host_option(self, host, name):
         default_options = self.config["options"]

--- a/src/mrack/transformers/virt.py
+++ b/src/mrack/transformers/virt.py
@@ -17,7 +17,7 @@
 import secrets
 
 from mrack.providers.provider import STRATEGY_ABORT
-from mrack.transformers.transformer import Transformer
+from mrack.transformers.transformer import DEFAULT_ATTEMPTS, Transformer
 
 CONFIG_KEY = "virt"
 
@@ -37,6 +37,7 @@ class VirtTransformer(Transformer):
         self.dsp_name = "Virt"
         await self._provider.init(
             strategy=self.config.get("strategy", STRATEGY_ABORT),
+            max_retry=self.config.get("max_retry", DEFAULT_ATTEMPTS),
         )
 
     def _get_host_option(self, host, name):


### PR DESCRIPTION
    feat(Beaker): use timeout instead of number of retries
    using number of retries is being replaced by timeout
    to help users to redefine easily using provisioning config
    timeout variable should be more user friendly

    feat: add possibility to change strategy per provider in provisioning config
    change default openstack behavior to abort

    refactor(Beaker): Use hub url in messages

    refactor(Beaker): fix the typo in message

    refactor(static): remove method which is inherited
    