### PR TITLE
fix: destroy active VMs after other providers fail

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -266,7 +266,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
             status = resource["status"]
             job_url = (
                 f"{self.hub._hub_url}"  # pylint: disable=protected-access
-                f"jobs/{resource['id']}"
+                f"/jobs/{resource['id']}"
             )
 
             if prev_status != status:

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -209,6 +209,7 @@ class PodmanProvider(Provider):
         insp_data = await self.podman.inspect(host_id)
         networks = insp_data[0]["NetworkSettings"]["Networks"]
         # then we destroy the container
+        logger.info(f"{self.dsp_name}: Removing container {host_id}")
         deleted = await self.podman.rm(host_id, force=True)  # TODO use stop and then rm
         # after that we cleanup the podman network
         for net in networks:

--- a/src/mrack/providers/virt.py
+++ b/src/mrack/providers/virt.py
@@ -144,6 +144,7 @@ class VirtProvider(Provider):
 
     async def delete_host(self, host_id):
         """Delete provisioned host."""
+        logger.info(f"{self.dsp_name}: Removing VM {host_id}")
         _out, _err, _proc = await self.testcloud.destroy(host_id)
         return True
 


### PR DESCRIPTION
    fix(Virt): Add de-sync state and fix error parsing.

    fix: destroy active VMs after other providers fail

    Fixing the use case with multi provider failed run.
    In case of at least 2 providers in metadata and one
    failing, successfully provisioned hosts were not
    destroyed as part of freeing resources.
    e.g.:
    if:
    - Beaker fails
    - Openstack succeeds
    then
    - Beaker cancel jobs
    - Openstack resources keeps hanging not destroyed.
    Adding block of code to raise an exception when
    other than ProvisioningError occurred.
    
Resolves: https://github.com/neoave/mrack/issues/129
