### PR TITLE
feat(AWS): support provisioning of different arch

### DIFF
--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -50,8 +50,9 @@ virt:
 
 aws:  # aws provider config
     images:
-        # list of ami images key is used in metadata ami image is used for provider e.g.
-        fedora-32: ami-0f1d60751946b66c5  # Fedora-Cloud-Base-32-1.6.x86_64-hvm-eu-central-1-gp2-0
+        # list of ami images based on arch (ami image used in metadata is overriding) e.g.
+        x86_64:
+            fedora-32: ami-0f1d60751946b66c5  # Fedora-Cloud-Base-32-1.6.x86_64-hvm-eu-central-1-gp2-0
 
 
     flavors:

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -48,10 +48,15 @@ class AWSTransformer(Transformer):
 
     def create_host_requirement(self, host):
         """Create single input for AWS provisioner."""
-        required_image = host.get("image") or self._get_image(host["os"])
+        req_arch = host.get("arch", "x86_64")
+        arch_images = self.config.get("images")
+        req_image = host.get("image") or self._get_image(
+            host["os"], config_key=req_arch, provider_config=arch_images
+        )
+
         return {
             "name": host["name"],
             "flavor": self._get_flavor(host),
-            "image": required_image,
+            "image": req_image,
             "meta_image": "image" in host,
         }

--- a/src/mrack/transformers/transformer.py
+++ b/src/mrack/transformers/transformer.py
@@ -68,7 +68,7 @@ class Transformer:
         """Add host input."""
         self._hosts.append(host)
 
-    def _get_image(self, operating_system, config_key="images"):
+    def _get_image(self, operating_system, config_key="images", provider_config=None):
         """
         Get image name by OS name from provisioning config.
 
@@ -77,8 +77,11 @@ class Transformer:
             2. default from the images if os is not found in keys
             3. os name if default is not specified for images.
         """
+        if not provider_config:
+            provider_config = self.config
+
         image = get_config_value(
-            self.config[config_key], operating_system, operating_system
+            provider_config[config_key], operating_system, operating_system
         )
         logger.debug(
             f"{self.dsp_name}: Loaded image for {operating_system}"


### PR DESCRIPTION
AWS now support provisioning based on arch key from
host configuration (default: x86_64).
image is then selected from slightly modified format
for the aws provider from provisioning-config.yaml
where all the images are divided into groups
based on arch they are designed to be used.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>