### PR TITLE
feat(Beaker): Add parsing of hostRequires to the job

### DIFF
--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -66,4 +66,5 @@ class BeakerTransformer(Transformer):
             "meta_distro": "distro" in host,
             "arch": host.get("arch", "x86_64"),
             "variant": self._get_bkr_variant(host),
+            f"mrack_{CONFIG_KEY}": host.get(CONFIG_KEY, {}),
         }

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -25,6 +25,7 @@ import os
 import subprocess
 import sys
 from functools import update_wrapper
+from xml.dom.minidom import Document as xml_doc
 
 import yaml
 
@@ -62,6 +63,19 @@ def validate_dict_attrs(dct, attr_list, dct_name):
         'Is missing required attributes: {missing}'
         """
         raise ConfigError(error)
+
+
+def add_dict_to_node(node, input_dict):
+    """Convert dict object to XML elements."""
+    # Recursively create xml from dict
+    if isinstance(input_dict, dict):
+        for key, value in input_dict.items():
+            if key.startswith("_"):
+                node.setAttribute(key[1:], str(value))
+            else:
+                node.appendChild(add_dict_to_node(xml_doc().createElement(key), value))
+
+    return node
 
 
 def json_convertor(obj):


### PR DESCRIPTION
mrack now supports the hostRequires in the host metadata
or default in provisioning config yaml.

# NOTE CASE MATTERS:

The hostRequires for the host should look like following:
```yaml
hostRequires:
  or:
    - hostname:
        _value: foo1.bar.baz.com
        _op: "="
    - hostname:
        _value: foo2.bar.baz.com
        _op: "="
  and:
    - system:
        memory:
          _value: 8000
          _op: ">"
    - arch:
        _value: x86_64
        _op: "="
    - system_type:
        _value: Machine
        _op: "="
    - key_value:
        _key: HVM
        _value: 1
        _op: "="
    - disk:
        size:
          _value: 137438953472
          _op: ">"
```
Which will result into following xml for the job specification:
```xml
<hostRequires>
  <or>
    <hostname value="foo1.bar.baz.com" op="="/>
    <hostname value="foo2.bar.baz.com" op="="/>
  </or>
  <and>
    <system>
      <memory value="8000" op="&gt;"/>
    </system>
    <arch value="x86_64" op="="/>
    <system_type value="Machine" op="="/>
    <key_value key="HVM" value="1" op="="/>
    <disk>
      <size value="137438953472" op="&gt;"/>
    </disk>
  </and>
</hostRequires>
```
and such requirement will be uploaded to the beaker hub
and schedule a job with this requirements.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>