### PR TITLE
fix(OpenStack): Changes for AD hostname for the requirement

### DIFF
--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -80,6 +80,7 @@ class PytestMultihostOutput:
         for domain in mhcfg["domains"]:
             for host in domain["hosts"]:
                 provisioned_host = self._db.hosts.get(host["name"])
+
                 if not provisioned_host:
                     logger.error(f"Host {host['name']} not found in the database.")
                     continue

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -70,12 +70,9 @@ class PytestMultihostOutput:
         ]
 
         # Use values from provisioning-config mhcfg section - as default values
-        for option in self._config["mhcfg"]:
-            # options defined in metadata takes precedence over options in
-            # provisioning-config as it is "closer" to user.
-            if option in mhcfg:
-                continue
-            mhcfg[option] = self._config["mhcfg"][option]
+        # options defined in metadata takes precedence over options in
+        # provisioning-config as it is "closer" to user.
+        mhcfg = self._config["mhcfg"] | mhcfg
 
         for domain in mhcfg["domains"]:
             for host in domain["hosts"]:

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -167,7 +167,8 @@ def get_host_from_metadata(metadata, name):
     domains = metadata.get("domains", [])
     for domain in domains:
         for host in domain.get("hosts", []):
-            if host["name"] == name:
+            # use startswith as for ad we use only first part of FQDN
+            if host["name"].startswith(name):  # FIXME here we use it
                 return host, domain
 
     return None, None


### PR DESCRIPTION
fix(OpenStack): Use only first part of fqdn for host name

if the host name contains "." character which is not supported for
windows OS as host name or the host name is an FQDN we use only
first part of domain name as host identifier for openstack

refactor: use builtin operator to merge dictionary

mhcfg section from provisioning-config is default
and could be extended by user provided mhcfg section
from metadata, thus using this order for `|` operator