### PR TITLE
feat: shortnames for windows machines in Openstack provider + shortname in Ansible inventory

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -23,6 +23,7 @@ from mrack.outputs.utils import resolve_hostname
 from mrack.utils import (
     get_host_from_metadata,
     get_password,
+    get_shortname,
     get_ssh_key,
     get_username,
     is_windows_host,
@@ -140,6 +141,7 @@ class AnsibleInventoryOutput:
             "ansible_python_interpreter": python,
             "ansible_user": ansible_user,
             "meta_fqdn": name,
+            "meta_hostname": get_shortname(name),
             "meta_domain": meta_domain["name"],
             "meta_provider": db_host.provider.name,
             "meta_provider_id": db_host.host_id,

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -189,7 +189,7 @@ class AWSProvider(Provider):
         # returns id of provisioned instance and required host name
         return (ids[0], req)
 
-    def prov_result_to_host_data(self, prov_result):
+    def prov_result_to_host_data(self, prov_result, req):
         """Transform provisioning result to needed host data."""
         # init the dict
         result = {}
@@ -222,7 +222,7 @@ class AWSProvider(Provider):
                 f"of provisioned instance '{req['name']}'"
             ) from data_err
 
-        return result
+        return result, req
 
     async def delete_host(self, host_id):
         """Delete provisioned hosts based on input from provision_hosts."""

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -273,7 +273,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
 
         return (job_id, req)
 
-    def prov_result_to_host_data(self, prov_result):
+    def prov_result_to_host_data(self, prov_result, req):
         """Transform provisioning result to needed host data."""
         try:
             ip_address = socket.gethostbyname(prov_result["system"])
@@ -389,7 +389,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
                 "mrack_req": req,
             }
         )
-        return resource
+        return resource, req
 
     async def delete_host(self, host_id):
         """Delete provisioned hosts based on input from provision_hosts."""
@@ -413,6 +413,6 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
             host_id, "cancel", "Job has been stopped by mrack."
         )
 
-    def to_host(self, provisioning_result, username="root"):
+    def to_host(self, provisioning_result, req, username="root"):
         """Transform provisioning result into Host object."""
-        return super().to_host(provisioning_result, username)
+        return super().to_host(provisioning_result, req, username)

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -696,7 +696,7 @@ class OpenStackProvider(Provider):
 
         server.update({"mrack_req": req})
 
-        return server
+        return server, req
 
     async def delete_host(self, host_id):
         """Issue deletion of host(server) from OpenStack."""
@@ -704,7 +704,7 @@ class OpenStackProvider(Provider):
         await self.delete_server(host_id)
         return True
 
-    def prov_result_to_host_data(self, prov_result):
+    def prov_result_to_host_data(self, prov_result, req):
         """Get needed host information from openstack provisioning result."""
         result = {}
 

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -213,7 +213,7 @@ class PodmanProvider(Provider):
 
         server.update({"mrack_req": req})
 
-        return server
+        return server, req
 
     async def delete_host(self, host_id):
         """Delete provisioned host."""
@@ -248,7 +248,7 @@ class PodmanProvider(Provider):
 
         return status
 
-    def prov_result_to_host_data(self, prov_result):
+    def prov_result_to_host_data(self, prov_result, req):
         """Get needed host information from podman provisioning result."""
         result = {}
 
@@ -281,7 +281,7 @@ class PodmanProvider(Provider):
 
         return result
 
-    def to_host(self, provisioning_result, username=None):
+    def to_host(self, provisioning_result, req, username=None):
         """Transform provisioning result into Host object."""
         # for containers use always root user
-        return super().to_host(provisioning_result, username="root")
+        return super().to_host(provisioning_result, req, username="root")

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -327,7 +327,7 @@ class Provider:
         )
         logger.info(f"{self.dsp_name}: Provisioning duration: {provisioned - started}")
 
-        hosts = [self.to_host(srv) for srv in server_results if srv]
+        hosts = [self.to_host(srv, req) for srv, req in server_results if srv]
 
         error_hosts += await self.parse_error_hosts(hosts)
         active_hosts = [h for h in hosts if h not in error_hosts]
@@ -469,13 +469,13 @@ class Provider:
         logger.info(f"{self.dsp_name}: All servers issued to be deleted")
         return results
 
-    def prov_result_to_host_data(self, prov_result):
+    def prov_result_to_host_data(self, prov_result, req):
         """Transform provisioning result to needed host data."""
         raise NotImplementedError()
 
-    def to_host(self, provisioning_result, username=None):
+    def to_host(self, provisioning_result, req, username=None):
         """Transform provisioning result into Host object."""
-        host_info = self.prov_result_to_host_data(provisioning_result)
+        host_info = self.prov_result_to_host_data(provisioning_result, req)
 
         host = Host(
             self,

--- a/src/mrack/providers/static.py
+++ b/src/mrack/providers/static.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 
 from mrack.errors import ValidationError
 from mrack.host import STATUS_ACTIVE
-from mrack.providers.provider import SPECS, STRATEGY_ABORT, Provider
+from mrack.providers.provider import STRATEGY_ABORT, Provider
 
 PROVISIONER_KEY = "static"
 
@@ -67,20 +67,19 @@ class StaticProvider(Provider):
     async def provision_hosts(self, reqs):
         """Fake provision - behave as if it was provisioned."""
         await self.validate_hosts(reqs)
-        hosts = [self.to_host(req) for req in reqs]
+        hosts = [self.to_host(req, req) for req in reqs]
         return hosts
 
     async def wait_till_provisioned(self, resource):
         """Wait till resource is provisioned."""
-        server = resource[SPECS]
-        return server
+        return resource
 
-    def prov_result_to_host_data(self, prov_result):
+    def prov_result_to_host_data(self, prov_result, req):
         """Transform provisioning result to needed host data."""
         result = {}
 
         result["id"] = prov_result.get("name")
-        result["name"] = prov_result.get("name")
+        result["name"] = req.get("name")
         result["addresses"] = [prov_result.get("ip")]
         result["fault"] = {}
         result["status"] = STATUS_ACTIVE

--- a/src/mrack/providers/virt.py
+++ b/src/mrack/providers/virt.py
@@ -146,7 +146,7 @@ class VirtProvider(Provider):
         """Wait till resource is provisioned."""
         result, req = resource
         result.update({"mrack_req": req})
-        return result
+        return result, req
 
     async def delete_host(self, host_id):
         """Delete provisioned host."""
@@ -159,7 +159,7 @@ class VirtProvider(Provider):
 
         return True
 
-    def prov_result_to_host_data(self, prov_result):
+    def prov_result_to_host_data(self, prov_result, req):
         """Get needed host information from podman provisioning result."""
         result = {}
         result["id"] = prov_result.get("id")

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -187,6 +187,15 @@ def is_windows_host(meta_host):
     )
 
 
+def get_shortname(hostname):
+    """
+    Get shortname part of fqdn.
+
+    Return the same string if it is not fqdn.
+    """
+    return hostname.split(".")[0]
+
+
 def get_username(host, meta_host, config):
     """Find username from sources db/metadata/config."""
     username = host.username or meta_host.get("username")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from mrack.utils import get_shortname
+
+
+@pytest.mark.parametrize(
+    "hostname,expected",
+    [
+        ("abc", "abc"),
+        ("foo.bar.baz", "foo"),
+        ("foo.", "foo"),
+        (".", ""),
+    ],
+)
+def test_get_shortname(hostname, expected):
+    assert get_shortname(hostname) == expected


### PR DESCRIPTION
This is  an alternative implementation to https://github.com/neoave/mrack/pull/146 consisting of 3 changes. The actual fix, which is very small + 2 preparations where refactoring to pass the `req` is the biggest.

**fix(openstack): use shortnames for Windows vm names**
Windows machines get hostname often by Cloudbase-Init. But
windows host support setting only shortnames (domain is added
when the host joins AD domain). OpenStack derives the hostnane
from vm name (until nova version 2.90 where hostname attr is added).
Thus we set shortname to support this also on older OpenStacks.

**feat: add shortname in Ansible inventory output**
It is added in meta_hostname attribute as often shortnames are
referred as hostnames.

**refactor: pass req to to_host method**
Or in other words, do not loose it/return it from
wait_till_provisioned method.

That way a provider can loose all info about req
- even the host name and to_host will still have this
info accessible.