### PR TITLE
fix(OpenStack): Do not raise exception when using unavailable network

### DIFF
--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -206,6 +206,9 @@ class OpenStackProvider(Provider):
         networks = [self.get_network(net) for net in possible_networks]
         usable = []
         for network in networks:
+            if not network:
+                continue
+
             ips = self.get_ips(ref=network.get("id"))
 
             available = ips["total_ips"] - ips["used_ips"]
@@ -301,6 +304,13 @@ class OpenStackProvider(Provider):
         network = self.networks.get(name)
         if not network:
             network = self.networks_by_ref.get(ref)
+
+        if not network:
+            net_id = name or ref
+            logger.debug(
+                f"{self.dsp_name}: Failed to load network with name: '{net_id}'"
+            )
+
         return network
 
     def get_ips(self, name=None, ref=None):


### PR DESCRIPTION
In some cases when network has an outage or is temporarily
removed etc. mrack would raise an exception when getting
the "id" from network which is set to 'None' which is
obvious AttributeError: 'NoneType' object has no attribute 'get'

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>