### PR TITLE
fix(Virt): Handle traceback when image is not accessible

### DIFF
--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -364,7 +364,8 @@ class Provider:
         Return list of information about provisioned servers.
         """
         logger.info(f"{self.dsp_name}: Preparing provider resources")
-        await self.prepare_provisioning(reqs)
+        if not await self.prepare_provisioning(reqs):
+            raise ProvisioningError("Failed to prepare resources", self.dsp_name)
 
         if self.strategy == STRATEGY_RETRY:
             success_hosts, error_hosts, _missing_reqs = await self.strategy_retry(reqs)


### PR DESCRIPTION
When image for Virt provider is not accessible we
happen to raise an exception:
TypeError: 'TestcloudImageError' object is not iterable
This should fix above exception and also tune behavior
when preparation of resources is failing.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>