### PR TITLE
fix: prepare_provisioning now shall return bool value

### DIFF
--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -94,7 +94,7 @@ class AWSProvider(Provider):
 
     async def prepare_provisioning(self, reqs):
         """Prepare provisioning."""
-        pass
+        return bool(reqs)
 
     async def validate_hosts(self, reqs):
         """Validate that host requirements are well specified."""

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -138,7 +138,7 @@ class BeakerProvider(Provider):
 
     async def prepare_provisioning(self, reqs):
         """Prepare provisioning."""
-        pass
+        return bool(reqs)
 
     async def can_provision(self, hosts):
         """Check that hosts can be provisioned."""

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -471,6 +471,7 @@ class OpenStackProvider(Provider):
             logger.debug(f"{self.dsp_name}: Loading images info done.")
 
         self._set_poll_sleep_times(reqs)
+        return True
 
     async def validate_hosts(self, reqs):
         """Validate that all hosts requirements contains existing required objects."""

--- a/src/mrack/providers/static.py
+++ b/src/mrack/providers/static.py
@@ -44,7 +44,7 @@ class StaticProvider(Provider):
 
     async def prepare_provisioning(self, reqs):
         """Prepare provisioning."""
-        pass
+        return bool(reqs)
 
     async def create_server(self, req):
         """Request and create resource on selected provider."""


### PR DESCRIPTION
Based on latest changes method prepare_provisioning
should return boolean value which means succes/fail
ref: a0de8475659153fd3fb39133a34f56729d0e561c

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>