### PR TITLE
fix: SSH action - do not redirect to PIPEs

### DIFF
--- a/src/mrack/actions/ssh.py
+++ b/src/mrack/actions/ssh.py
@@ -84,7 +84,11 @@ class SSH(Action):
             host, global_context
         )
         return utils_ssh_to_host(
-            host, username=username, password=password, ssh_key=ssh_key
+            host,
+            username=username,
+            password=password,
+            ssh_key=ssh_key,
+            interactive=True,
         )
 
     def is_container_env(self, host):

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -243,6 +243,7 @@ def ssh_to_host(
     password=None,
     ssh_key=None,
     command=None,
+    interactive=False,
 ):
     """SSH to the selected host."""
     psw = host.password or password
@@ -250,9 +251,14 @@ def ssh_to_host(
     run_args = {
         "env": os.environ.copy(),
         "shell": True,
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
     }
+    if not interactive:
+        run_args.update(
+            {
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.PIPE,
+            }
+        )
 
     cmd = ["ssh"]
     cmd.extend(["-o", "'StrictHostKeyChecking=no'"])
@@ -279,11 +285,12 @@ def ssh_to_host(
     process = subprocess.Popen(cmd, **run_args)
     std_out, std_err = process.communicate()
 
-    for o_line in std_out.decode().splitlines():
-        logger.debug(f"stdout: {o_line}")
+    if not interactive:
+        for o_line in std_out.decode().splitlines():
+            logger.debug(f"stdout: {o_line}")
 
-    for e_line in std_err.decode().splitlines():
-        logger.debug(f"stderr: {e_line}")
+        for e_line in std_err.decode().splitlines():
+            logger.debug(f"stderr: {e_line}")
 
     return process.returncode == 0
 


### PR DESCRIPTION
SSH action was previously redirected to PIPEs and thus it stopped
working from a user perspective as nothing was visible.

This patch is bringing the original behavior back.

Regression was caused by commit: 19d513ba246ef4be02a0ce3d22fbb0faea971ce8

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>