### PR TITLE
feat: search also provider config for username

### DIFF
--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -263,13 +263,15 @@ def get_shortname(hostname):
 
 def get_username(host, meta_host, config):
     """Find username from sources db/metadata/config."""
-    username = host.username or meta_host.get("username")
-    default_user = get_config_value(config["users"], meta_host["os"])
-
+    provider = host.provider.name
+    dict_key = meta_host["os"]
+    default_user = None
     if is_windows_host(meta_host):
-        default_user = default_user or "Administrator"
+        default_user = "Administrator"
+    username = find_value_in_config_hierarchy(
+        config, provider, host, meta_host, "username", "users", dict_key, default_user
+    )
 
-    username = username or default_user
     return username
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,157 @@
+# Copyright 2021 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from mrack.config import ProvisioningConfig
+from mrack.host import STATUS_ACTIVE, Host
+
+"""Fixtures for unit tests."""
+
+
+@pytest.fixture
+def openstack_config():
+    return {
+        "strategy": "retry",
+        "max_retry": 5,
+        "images": {
+            "rhel-8.5": "osp-rhel-8-5",
+            "fedora-34": "osp-fedora34",
+            "win-2019": "osp-win-2019",
+        },
+        "flavors": {
+            "ipaserver": "test.medium",
+            "ipaclient": "test.micro",
+            "ad": "test.medium",
+            "default": "test.nano",
+        },
+        "networks": {
+            "IPv4": [
+                "test-net4-1",
+                "test-net4-2",
+                "test-net4-3",
+                "test-net4-4",
+            ],
+            "IPv6": [
+                "test-net6-1",
+            ],
+            "dual": [
+                "test-dual-1",
+                "test-dual-2",
+            ],
+        },
+        "default_network": "IPv4",
+        "keypair": "mrack-keypair",
+    }
+
+
+@pytest.fixture
+def aws_config():
+    return {
+        "images": {
+            "rhel-8.5": "ami-rhel-8-5",
+            "fedora-34": "ami-fedora34",
+            "win-2019": "ami-win-2019",
+        },
+        "flavors": {
+            "ipaserver": "t2.medium",
+            "ipaclient": "t2.micro",
+            "ad": "t2.medium",
+            "default": "t2.nano",
+        },
+        "users": {
+            "rhel-8.5": "ec2-user",
+        },
+        "keypair": "mrack-keypair.pem",
+        "security_group": "sg-something",
+        "credentials_file": "aws.key",
+        "profile": "default",
+        "instance_tags": {
+            "Name": "mrack-runner",
+            "mrack": "True",
+            "Persistent": "False",
+        },
+    }
+
+
+@pytest.fixture
+def provisioning_config(openstack_config, aws_config):
+    raw = {
+        "openstack": openstack_config,
+        "aws": aws_config,
+        "users": {
+            "rhel-8.5": "cloud-user",
+            "fedora-34": "fedora",
+            "win-2019": "Administrator",
+        },
+    }
+    return ProvisioningConfig(raw)
+
+
+@pytest.fixture
+def metahost1():
+    return {
+        "name": "ipa1.example.com",
+        "role": "first",
+        "group": "ipaserver",
+        "os": "rhel-8.5",
+    }
+
+
+@pytest.fixture
+def metahost_win():
+    return {
+        "name": "ipa1.example.com",
+        "role": "ad",
+        "group": "ad_root",
+        "os": "win-2019",
+        "network": "IPv4",
+    }
+
+
+def mock_provider(name):
+    mock = MagicMock()
+    name_prop = PropertyMock(return_value=name)
+    type(mock).name = name_prop
+    return mock
+
+
+def meta_to_host(meta_host, provider_key, host_id, ip_address):
+    return Host(
+        mock_provider(provider_key),
+        host_id,
+        meta_host["name"],
+        meta_host["os"],
+        meta_host["group"],
+        ip_address,
+        STATUS_ACTIVE,
+        {},
+    )
+
+
+@pytest.fixture
+def host1_aws(metahost1):
+    return meta_to_host(metahost1, "aws", "1", "192.168.0.128")
+
+
+@pytest.fixture
+def host1_osp(metahost1):
+    return meta_to_host(metahost1, "openstack", "2", "192.168.1.128")
+
+
+@pytest.fixture
+def host_win_aws(metahost_win):
+    return meta_to_host(metahost_win, "aws", "3", "192.168.0.129")

--- a/tests/unit/test_config_search.py
+++ b/tests/unit/test_config_search.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mrack.utils import find_value_in_config_hierarchy
+
+"""Tests for ProvisioningConfig and searching in config hierarchy."""
+
+
+def test_find_value_in_config_hierarchy(
+    provisioning_config, host1_aws, host1_osp, metahost1, host_win_aws, metahost_win
+):
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "aws",
+        host1_aws,
+        metahost1,
+        "username",
+        "users",
+        metahost1["os"],
+    )
+    assert value == "ec2-user"
+
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "openstack",
+        host1_osp,
+        metahost1,
+        "username",
+        "users",
+        metahost1["os"],
+    )
+    assert value == "cloud-user"
+
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "aws",
+        host_win_aws,
+        metahost_win,
+        "username",
+        "users",
+        metahost_win["os"],
+    )
+    assert value == "Administrator"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mrack.utils import get_shortname
+from mrack.utils import get_shortname, get_username
 
 
 @pytest.mark.parametrize(
@@ -14,3 +14,16 @@ from mrack.utils import get_shortname
 )
 def test_get_shortname(hostname, expected):
     assert get_shortname(hostname) == expected
+
+
+def test_get_username(
+    provisioning_config, host1_aws, host1_osp, metahost1, host_win_aws, metahost_win
+):
+    value = get_username(host1_aws, metahost1, provisioning_config)
+    assert value == "ec2-user"
+
+    value = get_username(host1_osp, metahost1, provisioning_config)
+    assert value == "cloud-user"
+
+    value = get_username(host_win_aws, metahost_win, provisioning_config)
+    assert value == "Administrator"


### PR DESCRIPTION
**feat: search also provider config for username**
    
Cloud images might have a different default user based on provider, e.g.
RHEL has ec2-user but OpenStack image has cloud-user. This allows to
define default user per OS in provider section of provisioning config.

**feat: find_value_in_config_hierarchy utility method**

For getting a configuration value from the most specific to the
least specific. Design in a way to be usable for multiple of attributes.

E.g. first looking in host object then host definition in metadata then
in provider configuration and then in global provisioning configuration.