### PR TITLE
feat: multiple aws enhancements (PrivateIPAddress, multiple security groups, Subnet)

### DIFF
--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -40,7 +40,6 @@ class AWSProvider(Provider):
         self.dsp_name = "AWS"
         self.ami_ids: typing.List[str] = []
         self.ssh_key = None
-        self.sec_group = None
         self.instance_tags = None
         self.max_retry = 1  # for retry strategy
         self.status_map = {
@@ -61,7 +60,6 @@ class AWSProvider(Provider):
         self,
         ami_ids,
         ssh_key,
-        sec_group,
         instance_tags,
         strategy=STRATEGY_ABORT,
         max_retry=1,
@@ -86,7 +84,6 @@ class AWSProvider(Provider):
 
         self.ami_ids = ami_ids
         self.ssh_key = ssh_key
-        self.sec_group = sec_group
         self.instance_tags = instance_tags
         login_end = datetime.now()
         login_duration = login_end - login_start
@@ -163,7 +160,7 @@ class AWSProvider(Provider):
                 MaxCount=1,
                 InstanceType=specs.get("flavor"),
                 KeyName=self.ssh_key,
-                SecurityGroupIds=[self.sec_group],
+                SecurityGroupIds=specs.get("security_group_ids", []),
             )
         except ClientError as creation_error:
             err_msg = (

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -161,6 +161,7 @@ class AWSProvider(Provider):
                 InstanceType=specs.get("flavor"),
                 KeyName=self.ssh_key,
                 SecurityGroupIds=specs.get("security_group_ids", []),
+                SubnetId=specs.get("subnet_id"),
             )
         except ClientError as creation_error:
             err_msg = (

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -187,6 +187,15 @@ class AWSProvider(Provider):
         # returns id of provisioned instance and required host name
         return (ids[0], req)
 
+    def get_ip_addresses(self, prov_result):
+        """Get IP address from a provisioning result."""
+        addresess = []
+        if prov_result.get("PublicIpAddress"):
+            addresess.append(prov_result.get("PublicIpAddress"))
+        if prov_result.get("PrivateIpAddress"):
+            addresess.append(prov_result.get("PrivateIpAddress"))
+        return addresess
+
     def prov_result_to_host_data(self, prov_result, req):
         """Transform provisioning result to needed host data."""
         # init the dict
@@ -197,7 +206,7 @@ class AWSProvider(Provider):
             if tag["Key"] == "name":
                 result["name"] = tag["Value"]  # should be one key "name"
 
-        result["addresses"] = [prov_result.get("PublicIpAddress")]
+        result["addresses"] = self.get_ip_addresses(prov_result)
         result["status"] = prov_result["State"]["Name"]
         result["os"] = prov_result.get("mrack_req").get("os")
         result["group"] = prov_result.get("mrack_req").get("group")

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -61,7 +61,7 @@ class AWSTransformer(Transformer):
     def create_host_requirement(self, host):
         """Create single input for AWS provisioner."""
         required_image = host.get("image") or self._get_image(host["os"])
-        return {
+        req = {
             "name": host["name"],
             "os": host["os"],
             "group": host["group"],
@@ -70,3 +70,6 @@ class AWSTransformer(Transformer):
             "meta_image": "image" in host,
             "security_group_ids": self._get_security_groups(),
         }
+        if self.config.get("subnet_id"):
+            req["subnet_id"] = self.config.get("subnet_id")
+        return req


### PR DESCRIPTION
Requires: https://github.com/neoave/mrack/pull/158

**feat(aws): support for PrivateIpAddress**

When instance is provisioned with VPC which does not have a public
IP address, mrack is not able to get IP and fails. So changing the
behavior to try also Private IP if Public is not present.

**feat(aws): subnet support**

Adding possibility to define subnet to use for the instances. This
is needed, e.g. when instance needs to use a non-default VPC.

**feat(aws): multiple security groups**

Add support to be able to use multiple security groups and thus be able
to fine tune the inbount and outbound commnucation rules.

Note: there might be a small regression in validation in multiple security groups patch, where there is a possibility for alternate definitions but one is required and the other not. Not sure if we want to fix it - thus up to comments.