### PR TITLE
refactor: use hierarchy search for images and distros

### DIFF
--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -60,13 +60,12 @@ class AWSTransformer(Transformer):
 
     def create_host_requirement(self, host):
         """Create single input for AWS provisioner."""
-        required_image = host.get("image") or self._get_image(host["os"])
         req = {
             "name": host["name"],
             "os": host["os"],
             "group": host["group"],
             "flavor": self._get_flavor(host),
-            "image": required_image,
+            "image": self._get_image(host),
             "meta_image": "image" in host,
             "security_group_ids": self._get_security_groups(),
         }

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -57,9 +57,7 @@ class BeakerTransformer(Transformer):
 
     def create_host_requirement(self, host):
         """Create single input for Beaker provisioner."""
-        required_distro = host.get("distro") or self._get_image(
-            host["os"], config_key="distros"
-        )
+        required_distro = self._find_value(host, "distro", "distros", host["os"])
         return {
             "name": host["name"],
             "distro": required_distro,

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -61,13 +61,12 @@ class OpenStackTransformer(Transformer):
 
     def create_host_requirement(self, host):
         """Create single input for OpenStack provisioner."""
-        required_image = host.get("image") or self._get_image(host["os"])
         req = {
             "name": host["name"],
             "os": host["os"],
             "group": host["group"],
             "flavor": self._get_flavor(host),
-            "image": required_image,
+            "image": self._get_image(host),
             "key_name": self.config["keypair"],
             "network": self._get_network_type(host),
         }

--- a/src/mrack/transformers/podman.py
+++ b/src/mrack/transformers/podman.py
@@ -51,7 +51,7 @@ class PodmanTransformer(Transformer):
         _host, domain = get_host_from_metadata(self._metadata, host["name"])
         return {
             "name": host["name"],
-            "image": self._get_image(host["os"]),
+            "image": self._get_image(host),
             "os": host["os"],
             "group": host["group"],
             "hostname": host["name"],

--- a/src/mrack/transformers/virt.py
+++ b/src/mrack/transformers/virt.py
@@ -55,7 +55,7 @@ class VirtTransformer(Transformer):
             "os": host["os"],
             "group": host["group"],
             "run_id": self.run_id,
-            "image_url": self._get_image(host["os"]),
+            "image_url": self._get_image(host),
             "ssh_path": self._get_host_option(host, "ssh_path"),
         }
 


### PR DESCRIPTION
It may change some behavior a little but is mostly a refactoring.

This is unifying the logic to get image definitions across transformers.

WiIl use it as a base for a next patch in `aws` provider to get images by tag. 