### PR TITLE
feat(aws): defining AMIs by tags

### DIFF
--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -38,7 +38,6 @@ class AWSTransformer(Transformer):
         """Initialize associate provider and transformer display name."""
         self.dsp_name = "AWS"
         await self._provider.init(
-            ami_ids=self.config["images"].values(),
             ssh_key=self.config["keypair"],
             instance_tags=self.config["instance_tags"],
             strategy=self.config.get("strategy", STRATEGY_ABORT),
@@ -66,7 +65,6 @@ class AWSTransformer(Transformer):
             "group": host["group"],
             "flavor": self._get_flavor(host),
             "image": self._get_image(host),
-            "meta_image": "image" in host,
             "security_group_ids": self._get_security_groups(),
         }
         if self.config.get("subnet_id"):


### PR DESCRIPTION
rebased on top of: https://github.com/neoave/mrack/pull/161

Add a new way to define an AWS EC2 image in a provisiong config in addition to ami ID.

The following is valid:
```
images:
  fedora-34: ami-0d3c5199abb29a7ae
  fedora-35: { tag: { name: compose, value: mrack-fedora-35-latest } }
```

This allows for a seperate tool to upload new image with the same purpose and mrack automatically picks the latest one with the given tag.

Currently only one tag is supported and it searches in all images.

Possible improvements:
- more tags
- limiting to private images

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>