### PR TITLE
feat(aws): request spot instances

### DIFF
--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -66,6 +66,7 @@ class AWSTransformer(Transformer):
             "flavor": self._get_flavor(host),
             "image": self._get_image(host),
             "security_group_ids": self._get_security_groups(),
+            "spot": self._find_value(host, "spot", None, None),
         }
         if self.config.get("subnet_id"):
             req["subnet_id"] = self.config.get("subnet_id")

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -63,11 +63,12 @@ def get_value_or_dict_value(config_dict, attr, dict_name, key):
         return None
 
     value = None
-    value_dict = config_dict.get(dict_name)
-    if value_dict:
-        value = get_config_value(value_dict, key)
-        if value:
-            return value
+    if dict_name and key:
+        value_dict = config_dict.get(dict_name)
+        if value_dict:
+            value = get_config_value(value_dict, key)
+            if value:
+                return value
 
     value = config_dict.get(attr)
     return value

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -79,6 +79,7 @@ def aws_config():
         "security_group": "sg-something",
         "credentials_file": "aws.key",
         "profile": "default",
+        "spot": True,
         "instance_tags": {
             "Name": "mrack-runner",
             "mrack": "True",

--- a/tests/unit/test_config_search.py
+++ b/tests/unit/test_config_search.py
@@ -52,3 +52,47 @@ def test_find_value_in_config_hierarchy(
         metahost_win["os"],
     )
     assert value == "Administrator"
+
+
+def test_find_simple_value_in_hierarchy(
+    provisioning_config, host1_aws, metahost1, host_win_aws, metahost_win
+):
+    """
+    Test spot configuration for aws.
+
+    But also tests finding value when dict_name and key are not defined.
+    """
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "aws",
+        host1_aws,
+        metahost1,
+        "spot",
+        None,
+        None,
+    )
+    assert value is True
+
+    provisioning_config["aws"]["spot"] = False
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "aws",
+        host1_aws,
+        metahost1,
+        "spot",
+        None,
+        None,
+    )
+    assert value is False
+
+    metahost1["spot"] = True
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "aws",
+        host1_aws,
+        metahost1,
+        "spot",
+        None,
+        None,
+    )
+    assert value is True


### PR DESCRIPTION
This is only 1 commit but rebased on top of https://github.com/neoave/mrack/pull/162 (which is on top of https://github.com/neoave/mrack/pull/161 )

    
Spot instances are a great way how to save money for CI purposes.

https://aws.amazon.com/ec2/spot

This is inital implementation where the only possible option is to
ask for spot instance, but not define SpotOptions - this can be
extended later if wanted.

How to use:
- set `spot: True` in `aws` provider to enable it globally
- set `spot: True` in host section in job metadata file to request
  a spot instance for this particular host.

Additional changes:
- removes stopping instance on destroy as it doesn't work with
  default behaviour of spot instances + correctly handle exception when
  stopping fails (previous behaviour crashed mrack)
- prepares a parameters dict to be able to control what is passed to
  ec2.create_instances, + partly fixes a possible regression with
  SubNetId

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>