### PR TITLE
feat: possibility to disable host DNS resolution in outputs

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -19,7 +19,7 @@ import typing
 from copy import deepcopy
 
 from mrack.errors import ConfigError
-from mrack.outputs.utils import resolve_hostname
+from mrack.outputs.utils import get_external_id
 from mrack.utils import (
     get_host_from_metadata,
     get_password,
@@ -124,7 +124,7 @@ class AnsibleInventoryOutput:
         db_host = self._db.hosts[name]
 
         ip_addr = db_host.ip_addr
-        ansible_host = resolve_hostname(ip_addr) or ip_addr
+        ansible_host = get_external_id(db_host, meta_host, self._config)
 
         python = (
             self._config["python"].get(meta_host["os"])

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -18,7 +18,7 @@ import logging
 import os
 from copy import deepcopy
 
-from mrack.outputs.utils import resolve_hostname
+from mrack.outputs.utils import get_external_id
 from mrack.utils import get_password, get_username, is_windows_host, save_yaml
 
 DEFAULT_MHCFG_PATH = "pytest-multihost.yaml"
@@ -87,15 +87,15 @@ class PytestMultihostOutput:
                 if password:
                     host["password"] = password
 
-                ip_addr = provisioned_host.ip_addr
-                dns_record = resolve_hostname(ip_addr)
-                host["ip"] = ip_addr
+                host["ip"] = provisioned_host.ip_addr
 
                 # Using IP as backup for external host name as pytest-multihost is using
                 # external_hostname as the host to use in ssh command.
                 # If it is not available it uses hostname, but we assume here that
                 # hostname is internal and thus not resolvable. IP should be resolvable.
-                host["external_hostname"] = dns_record or ip_addr
+                host["external_hostname"] = get_external_id(
+                    provisioned_host, host, self._config
+                )
 
                 if is_windows_host(host):
                     # Set username for Windows, as default for multihost is often 'root'

--- a/src/mrack/outputs/utils.py
+++ b/src/mrack/outputs/utils.py
@@ -17,6 +17,8 @@
 import socket
 from socket import error as socket_error
 
+from mrack.utils import find_value_in_config_hierarchy
+
 
 def resolve_hostname(ip_addr):
     """Resolve IP address to hostname."""
@@ -24,3 +26,22 @@ def resolve_hostname(ip_addr):
         return socket.gethostbyaddr(ip_addr)[0]
     except socket_error:
         return None
+
+
+def get_external_id(host, meta_host, config):
+    """
+    Get host's external ID.
+
+    That can be its resolvable DNS name (from IP) or the IP - based on provider or
+    host configuration (key: resolve_host, default True).
+
+    IP is used as fallback if the desired is not available.
+    """
+    resolve_ip = find_value_in_config_hierarchy(
+        config, host.provider.name, host, meta_host, "resolve_host", None, None, True
+    )
+
+    external_id = host.ip_addr
+    if resolve_ip:
+        external_id = resolve_hostname(host.ip_addr) or host.ip_addr
+    return external_id

--- a/tests/unit/test_output_utils.py
+++ b/tests/unit/test_output_utils.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for mrack.outputs.utils"""
+
+from unittest.mock import patch
+
+from mrack.outputs.utils import get_external_id
+
+
+@patch("mrack.outputs.utils.resolve_hostname")
+def test_get_external_id(mock_resolve, provisioning_config, host1_aws, metahost1):
+    """
+    Test that resolve_hostname is not called when it is not supposed to be.
+    """
+    dns = "my.dns.name"
+    mock_resolve.return_value = dns
+
+    # By default, it resolves DNS
+    ext_id = get_external_id(host1_aws, metahost1, provisioning_config)
+    assert ext_id == dns
+
+    # Disable in host metadata
+    metahost1["resolve_host"] = False
+    ext_id = get_external_id(host1_aws, metahost1, provisioning_config)
+    assert ext_id == host1_aws.ip_addr
+
+    # Disable in provider
+    del metahost1["resolve_host"]
+    provisioning_config["aws"]["resolve_host"] = False
+    ext_id = get_external_id(host1_aws, metahost1, provisioning_config)
+    assert ext_id == host1_aws.ip_addr
+
+    # Explicitly enabled in provider
+    provisioning_config["aws"]["resolve_host"] = True
+    ext_id = get_external_id(host1_aws, metahost1, provisioning_config)
+    assert ext_id == dns
+
+    # Resolution enabled, but nothing is resolved
+    mock_resolve.return_value = None
+    ext_id = get_external_id(host1_aws, metahost1, provisioning_config)
+    assert ext_id == host1_aws.ip_addr


### PR DESCRIPTION
Ansible inventory's `ansible_host` or pytest-multihost's `external_hostname` currently by default tries to resolve host's IP address and use the DNS name if resolution is successful.

This change allows to disable this behavior by setting:
   `resolve_host: False`
Somewhere in the configuration hierarchy (metadata host, provider config, or global provisioning config).

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>