### PR TITLE
feat(Beaker): Support distro variant configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_mode = strict
 addopts = -r fEsxXw --showlocals
 junit_family = xunit2
 testpaths =

--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -95,6 +95,17 @@ beaker:  # beaker provider specific values
     distros:
         # list of beaker distros key is used in metadata distro is used in generated jobxml
         fedora-32: Fedora-32%
+        c9s: CentOS-Stream-9%
+
+    # example of distribution variants configuration for beaker xml job
+    distro_variants:
+        default: Server
+        CentOS-Stream-9%: BaseOS
+
+    # example of beaker requirement tags for specific distributuions
+    distro_tags:
+        CentOS-Stream-9%:
+            - RC-0.1
 
     # path to public ssh key which is later uploaded to the machine for access
     pubkey: id_rsa.pub

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -47,7 +47,9 @@ class BeakerTransformer(Transformer):
 
     def _get_distro_and_variant(self, host):
         """Get distribution and its variant for the host system to requirement."""
-        required_distro = self._find_value(host, "distro", "distros", host["os"])
+        required_distro = self._find_value(
+            host, "distro", "distros", host["os"], default=host["os"]
+        )
         distro_variants = self.config.get("distro_variants")
 
         if "beaker_variant" in host:

--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -162,6 +162,7 @@ def provisioning_config(inventory_layout=None):
             "distros": {
                 "c9s": "CentOS-Stream-9%",
                 "fedora-36": "Fedora-36%",
+                "rhel-8.6": "RHEL-8.6%",
                 "fedora-latest": "Fedora-36%",
             },
             "distro_tags": {
@@ -183,6 +184,7 @@ def provisioning_config(inventory_layout=None):
             "fedora-30": "fedora",
             "fedora-31": "fedora",
             "rhel-8.2": "cloud-user",
+            "rhel-8.6": "cloud-user",
             "win-2019": "Administrator",
             "default": "cloud-user",
         },
@@ -190,6 +192,7 @@ def provisioning_config(inventory_layout=None):
             "fedora-30": "/usr/bin/python3",
             "fedora-31": "/usr/bin/python3",
             "rhel-8.2": "/usr/libexec/platform-python",
+            "rhel-8.6": "/usr/libexec/platform-python",
             "default": "/usr/bin/python3",
         },
     }

--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -3,6 +3,15 @@ import uuid
 from mrack.config import ProvisioningConfig
 from mrack.dbdrivers.file import FileDBDriver
 from mrack.host import STATUS_ACTIVE, Host
+from mrack.transformers.beaker import BeakerTransformer
+
+
+class MockedBeakerTransformer(BeakerTransformer):
+    """Mock Beaker transformer."""
+
+    async def init_provider(self):
+        """Override the init_provider to do nothing."""
+        pass
 
 
 class MockProvider:
@@ -147,6 +156,29 @@ def provisioning_config(inventory_layout=None):
     """Get basic provisioning config for testing."""
     cfg = {
         "ssh_key_filename": "config/id_rsa",
+        "beaker": {
+            "strategy": "retry",
+            "max_retry": 2,
+            "distros": {
+                "c9s": "CentOS-Stream-9%",
+                "fedora-36": "Fedora-36%",
+                "fedora-latest": "Fedora-36%",
+            },
+            "distro_tags": {
+                "CentOS-Stream-9%": [
+                    "RC-01",
+                ]
+            },
+            "distro_variants": {
+                "default": "BaseOS",
+                "CentOS-Stream-9%": "BaseOS",
+                "Fedora-36%": "Server",
+            },
+            "pubkey": "config/id_rsa.pub",
+            "reserve_duration": 86400,
+            "max_attempts": 240,
+            "timeout": 120,
+        },
         "users": {
             "fedora-30": "fedora",
             "fedora-31": "fedora",

--- a/tests/unit/test_beaker_transformer.py
+++ b/tests/unit/test_beaker_transformer.py
@@ -1,0 +1,88 @@
+import pytest
+
+from mrack.providers import providers
+from mrack.providers.beaker import PROVISIONER_KEY as BEAKER
+from mrack.providers.beaker import BeakerProvider
+
+from .mock_data import MockedBeakerTransformer, provisioning_config
+
+
+class TestBeakerTransformer:
+    """Test the Beaker Transformer"""
+
+    domain_name = "example.test"
+    ad_domain_name = "ad.test"
+
+    fedora = {
+        "name": f"fedora.{domain_name}",
+        "role": "client",
+        "group": "client",
+        "os": "fedora-latest",
+        "restraint_id": 1,
+    }
+
+    centos = {
+        "name": f"centos.{domain_name}",
+        "role": "server",
+        "group": "ipaserver",
+        "os": "c9s",
+        "restraint_id": 2,
+    }
+
+    windows = {
+        "name": f"ad1.{ad_domain_name}",
+        "role": "ad",
+        "group": "ad_root",
+        "os": "win-2022",
+        "domain_level": "top",
+        "netbios": ad_domain_name.split(".", maxsplit=1)[0].upper(),
+    }
+
+    hosts_metadata = {
+        "domains": [
+            {
+                "name": domain_name,
+                "type": "linux",
+                "hosts": [
+                    fedora,
+                    centos,
+                ],
+            },
+            {
+                "name": ad_domain_name,
+                "type": "linux",
+                "hosts": [
+                    windows,
+                ],
+            },
+        ],
+    }
+
+    @pytest.mark.asyncio
+    async def create_transformer(self):
+        """Initialize the Beaker transformer"""
+        providers.register(BEAKER, BeakerProvider)
+        res = MockedBeakerTransformer()
+        await res.init(
+            provisioning_config(),
+            self.hosts_metadata,
+        )
+        return res
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "meta_host,exp_distro,exp_variant",
+        [
+            (fedora, "Fedora-36%", "Server"),
+            (centos, "CentOS-Stream-9%", "BaseOS"),
+            # default variant should be there,
+            # windows distro does not exist so host['os'] should be copied
+            (windows, "win-2022", "BaseOS"),
+        ],
+    )
+    async def test_beaker_requirement(self, meta_host, exp_distro, exp_variant):
+        """Test expected Beaker VM variant and distro"""
+        bkr_transformer = await self.create_transformer()
+        req = bkr_transformer.create_host_requirement(meta_host)
+        assert req.get("distro") == exp_distro
+        assert req.get("variant") == exp_variant


### PR DESCRIPTION
Before this patch the distro variant could not be configured
and was hardcoded in the source code of the mrack project.
With this patch we support the old way and also a new way
of specifying the distro variants in the provisioning-config.

Updated the example provisioning-config.yaml file with latest
beaker feature examples.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>