### PR TITLE
chore: Update Black pre-commit hook version to 22.3.0 to solve click dependency issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         files: ^src/.*
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: ^docs/.*

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==22.3.0
 isort>=5.0.0
 flake8>=3.0.0
 pytest>=6.0.0


### PR DESCRIPTION
Recent release of Click makes current version of Black to break. This issue is solved in newest version of Black 22.3.0
See more about the issue in https://github.com/psf/black/issues/2964

Signed-off-by: David Pascual <davherna@redhat.com>