### PR TITLE
fix: image transformer none value in requirements 

### DIFF
--- a/src/mrack/transformers/transformer.py
+++ b/src/mrack/transformers/transformer.py
@@ -83,7 +83,9 @@ class Transformer:
     def _get_image(self, host):
         """Get image name by OS name from provisioning config."""
         operating_system = host["os"]
-        image = self._find_value(host, "image", "images", operating_system)
+        image = self._find_value(
+            host, "image", "images", operating_system, default=operating_system
+        )
 
         logger.debug(f"{self.dsp_name}: Found image {image} for {operating_system}")
         return image


### PR DESCRIPTION
When OS image in metadata is not found in provisioning
config, there was a traceback causing mrack to fail.
Adding default value solves the problem and prints expected message.