### PR TITLE
style: Increase readability of logs by using host

### DIFF
--- a/src/mrack/host.py
+++ b/src/mrack/host.py
@@ -193,6 +193,6 @@ class Host:
 
     async def delete(self):
         """Issue host deletion via associated provider."""
-        await self.provider.delete_host(self.host_id)
+        await self.provider.delete_host(self.host_id, self.name)
         self._status = STATUS_DELETED
         return True

--- a/src/mrack/providers/static.py
+++ b/src/mrack/providers/static.py
@@ -88,10 +88,11 @@ class StaticProvider(Provider):
 
         return result
 
-    async def delete_host(self, host_id):
+    async def delete_host(self, host_id, host_name):
         """Fake delete - pass but don't do anything."""
+        log_msg_start = f"{self.dsp_name} [{host_name}]"
         logger.info(
-            f"{self.dsp_name}: Host {host_id} is static"
+            f"{log_msg_start} Host with ID {host_id} is static"
             " - not managed by mrack, ignoring removal"
         )
         return bool(host_id)

--- a/src/mrack/providers/utils/podman.py
+++ b/src/mrack/providers/utils/podman.py
@@ -93,7 +93,7 @@ class Podman:
         _stdout, stderr, process = await self._run_podman(args, raise_on_err=False)
 
         if stderr:
-            logger.debug(f"{self.dsp_name}: {stderr.strip()}")
+            logger.debug(f"{self.dsp_name} {stderr.strip()}")
 
         return process.returncode == 0
 
@@ -124,10 +124,10 @@ class Podman:
     async def network_create(self, network):
         """Create a podman network if it does not exist."""
         if await self.network_exists(network):
-            logger.debug(f"{self.dsp_name}: Network '{network}' is present")
+            logger.debug(f"{self.dsp_name} Network '{network}' is present")
             return 0
 
-        logger.info(f"{self.dsp_name}: Creating podman network '{network}'")
+        logger.info(f"{self.dsp_name} Creating podman network '{network}'")
         args = ["network", "create", network]
         _stdout, _stderr, process = await self._run_podman(args, raise_on_err=False)
 
@@ -136,7 +136,7 @@ class Podman:
     async def network_remove(self, network):
         """Remove a podman network if it does exist."""
         if not await self.network_exists(network):
-            logger.debug(f"{self.dsp_name}: Network '{network}' does not exists")
+            logger.debug(f"{self.dsp_name} Network '{network}' does not exists")
             return True
 
         args = ["network", "remove", network]
@@ -148,13 +148,13 @@ class Podman:
         """Pull a container image."""
         args = ["pull", image]
         logger.info(
-            f"{self.dsp_name}: Pulling image '{image}'. This may take a while..."
+            f"{self.dsp_name} Pulling image '{image}'. This may take a while..."
         )
         _stdout, _stderr, process = await self._run_podman(args, raise_on_err=False)
         if process.returncode == 0:
-            logger.info(f"{self.dsp_name}: Pull of image '{image}' succeeded")
+            logger.info(f"{self.dsp_name} Pull of image '{image}' succeeded")
         else:
-            logger.error(f"{self.dsp_name}: Pull of image '{image}' failed")
+            logger.error(f"{self.dsp_name} Pull of image '{image}' failed")
 
         return process.returncode == 0
 

--- a/src/mrack/transformers/transformer.py
+++ b/src/mrack/transformers/transformer.py
@@ -88,6 +88,8 @@ class Transformer:
         )
 
         logger.debug(f"{self.dsp_name}: Found image {image} for {operating_system}")
+        log_msg_start = f"{self.dsp_name} [{host.get('name')}]"
+        logger.debug(f"{log_msg_start} Found image {image} for {operating_system}")
         return image
 
     def _get_flavor(self, host):
@@ -98,12 +100,14 @@ class Transformer:
         If 'size' is not specified, get the flavor based on host groups
         which are defined in provisioning config.
         """
+        log_msg_start = f"{self.dsp_name} [{host.get('name')}]"
+
         if host.get("size"):  # allow to override size by pointing to group in metadata
             flavor = get_config_value(self.config["flavors"], host["size"])
         else:  # default action based on host group define the flavor of instance
             flavor = get_config_value(self.config["flavors"], host["group"])
 
-        logger.debug(f"{self.dsp_name}: Loaded flavor for {host['name']}: '{flavor}'")
+        logger.debug(f"{log_msg_start} Loaded flavor '{flavor}'")
         return flavor
 
     def validate_config(self):
@@ -112,13 +116,15 @@ class Transformer:
 
     def validate_host(self, host):
         """Validate host input that it contains everything needed by provider."""
+        log_msg_start = f"{self.dsp_name} [{host.get('name')}]"
         # attribute check
         validate_dict_attrs(host, self._required_host_attrs, "host")
         # provider check
         provider = host.get("provider")
+
         if provider and provider not in providers.names:
             raise MetadataError(
-                f"{self.dsp_name}: Error: Invalid host provider: {provider}"
+                f"{log_msg_start} Error: Invalid host provider: {provider}"
             )
 
     def create_host_requirement(self, host):
@@ -128,5 +134,5 @@ class Transformer:
     def create_host_requirements(self):
         """Create inputs for all host for provisioner."""
         reqs = [self.create_host_requirement(host) for host in self.hosts]
-        logger.info(f"{self.dsp_name}: Created requirement(s): {object2json(reqs)}")
+        logger.info(f"{self.dsp_name} Created requirement(s): {object2json(reqs)}")
         return reqs


### PR DESCRIPTION
Adding a host name from metadata or host object
where it is possible to increase readability of
the log messages and better debugging with only
using the log content. Before this patch there
were logging messages that were describing the
error but from the log message we could not tell
which host was causing that.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>