### PR TITLE
feat(AWS): Move tagging into creation request itself

### DIFF
--- a/src/mrack/actions/up.py
+++ b/src/mrack/actions/up.py
@@ -95,7 +95,7 @@ class Up(Action):
                 # we need to cleanup all the remaining resources
                 # even when provisioned successfully
                 logger.error(
-                    f"{results.args[PROVIDER_NAME_INDEX]}: "
+                    f"{results.args[PROVIDER_NAME_INDEX]} "
                     f"{results.args[ERR_MSG_INDEX]}"
                 )
                 failed_providers.append(results.args[PROVIDER_NAME_INDEX])

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -196,7 +196,12 @@ class AWSProvider(Provider):
 
     async def prepare_provisioning(self, reqs):
         """Prepare provisioning."""
-        self.load_images(reqs)
+        try:
+            self.load_images(reqs)
+        except ValidationError as val_err:
+            logger.error(val_err)
+            return False
+
         return bool(reqs)
 
     async def validate_hosts(self, reqs):

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -231,6 +231,12 @@ class AWSProvider(Provider):
         specs = deepcopy(req)  # work with own copy, do not modify the input
 
         del_vol = specs.get("delete_volume_on_termination", True)
+
+        # creating name for instance (visible in aws ec2 WebUI)
+        taglist = [{"Key": "name", "Value": req.get("name")}]
+        for key, value in self.instance_tags.items():
+            taglist.append({"Key": key, "Value": value})
+
         request = {
             "ImageId": self.get_image(specs).image_id,
             "MinCount": 1,
@@ -246,6 +252,7 @@ class AWSProvider(Provider):
                     },
                 },
             ],
+            "TagSpecifications": [{"ResourceType": "instance", "Tags": taglist}],
         }
         if specs.get("subnet_id"):
             request["SubnetId"] = specs.get("subnet_id")
@@ -271,12 +278,6 @@ class AWSProvider(Provider):
         ids = [srv.id for srv in aws_res]
         if len(ids) != 1:  # ids must be len of 1 as we provision one vm at the time
             raise ProvisioningError("Unexpected number of instances provisioned.", req)
-        # creating name for instance (visible in aws ec2 WebUI)
-        taglist = [{"Key": "name", "Value": specs.get("name")}]
-        for key in self.instance_tags:
-            taglist.append({"Key": key, "Value": self.instance_tags[key]})
-
-        self.ec2.create_tags(Resources=ids, Tags=taglist)
 
         # returns id of provisioned instance and required host name
         return (ids[0], req)


### PR DESCRIPTION
Move tagging into creation request itself

When the creation of the instance is too slow
on the ec2 side we get a traceback that instance
does not exist (yet) and we need would need
to wait a bit in order to tag it.
Move tagging into request itself and do it at instance creation

adding some trivial patches:
- [refactor: remove collon from error string]
- [fix: return False when ValidationError is raised]