### PR TITLE
feat: copyign meta_ attributes from host to ansible inventory

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -120,6 +120,7 @@ class AnsibleInventoryOutput:
 
     def create_ansible_host(self, name):
         """Create host entry for Ansible inventory."""
+        # pylint: disable=too-many-locals
         meta_host, meta_domain = get_host_from_metadata(self._metadata, name)
         db_host = self._db.hosts[name]
 
@@ -183,6 +184,10 @@ class AnsibleInventoryOutput:
                     "meta_domain_level": meta_host.get("domain_level", "top"),
                 }
             )
+
+        for key, val in meta_host.items():
+            if key.startswith("meta_"):
+                host_info[key] = val
 
         return host_info
 

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -189,6 +189,10 @@ class AnsibleInventoryOutput:
             if key.startswith("meta_"):
                 host_info[key] = val
 
+        ansible_inventory = meta_host.get("ansible_inventory")
+        if isinstance(ansible_inventory, dict):
+            host_info.update(ansible_inventory)
+
         return host_info
 
     def create_inventory(self):

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -108,11 +108,19 @@ class PytestMultihostOutput:
                     if username:
                         host["username"] = username
 
-                if host["group"] == "ad_root":
+                group = host.get("group")
+                if not group:
+                    groups = host.get("groups")
+                    if isinstance(groups, list) and len(groups):
+                        group = groups[0]
+                    else:
+                        group = ""  # group is required, but not part of output
+
+                if group == "ad_root":
                     mhcfg["ad_top_domain"] = domain["name"]
                     mhcfg["ad_hostname"] = host["name"]
                     mhcfg["ad_ip"] = host["ip"]
-                elif host["group"] == "ad_subdomain":
+                elif group == "ad_subdomain":
                     mhcfg["ad_sub_domain"] = domain["name"]
                     mhcfg["ad_sub_hostname"] = host["name"]
                     mhcfg["ad_sub_ip"] = host["ip"]

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -72,7 +72,7 @@ class PytestMultihostOutput:
         # Use values from provisioning-config mhcfg section - as default values
         # options defined in metadata takes precedence over options in
         # provisioning-config as it is "closer" to user.
-        mhcfg = self._config["mhcfg"] | mhcfg
+        mhcfg = self._config.get("mhcfg", {}) | mhcfg
 
         for domain in mhcfg["domains"]:
             for host in domain["hosts"]:

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -125,9 +125,14 @@ class PytestMultihostOutput:
                     mhcfg["ad_sub_hostname"] = host["name"]
                     mhcfg["ad_sub_ip"] = host["ip"]
 
+                host_custom_attrs = host.get("pytest_multihost")
+
                 rm_keys = [key for key in host.keys() if key not in host_allowed_attrs]
                 for key in rm_keys:
                     del host[key]
+
+                if isinstance(host_custom_attrs, dict):
+                    host.update(host_custom_attrs)
 
             domain_rm_keys = [
                 key for key in domain.keys() if key not in ["name", "type", "hosts"]

--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -83,6 +83,36 @@ def create_metadata(ipaservers, ipaclients, ads):
     }
 
 
+def metadata_extra():
+    hosts = [
+        {
+            "name": "srv1.example.test",
+            "os": "windows-2019",
+            "role": "ad",
+            "groups": ["windows"],
+            "meta_readonly_dc": "yes",
+            "meta_something_else": "val",
+        },
+        {
+            "name": "srv2.example.test",
+            "os": "fedora",
+            "role": "master",
+            "groups": ["ipaserver"],
+            "meta_readonly_dc": "no",
+            "meta_os": "fedora-32",
+        },
+    ]
+    return {
+        "domains": [
+            {
+                "name": "example.test",
+                "type": "mixed",
+                "hosts": hosts,
+            }
+        ]
+    }
+
+
 def get_ip(index=0):
     """Get IPv4 IP from 192.168.0/24 network."""
     return f"192.168.0.{index+1}"

--- a/tests/unit/test_ansible_inventory.py
+++ b/tests/unit/test_ansible_inventory.py
@@ -190,4 +190,40 @@ class TestAnsibleInventory:
         assert "meta_something_else" not in srv2
         assert "meta_readonly_dc" in srv2
         assert srv2["meta_readonly_dc"] == "no"
-        assert srv2["meta_os"] == "windows-2022"
+        assert srv2["meta_os"] == "fedora-32"
+
+    def test_arbitrary_attrs(self):
+        """
+        Test that values defined in `ansible_inventory` dictionary in host part
+        of job metadata file gets into host attributes in generated ansible
+        inventory.
+        """
+        metadata = metadata_extra()
+        m_srv1 = metadata["domains"][0]["hosts"][0]
+        m_srv2 = metadata["domains"][0]["hosts"][1]
+        m_srv1["ansible_inventory"] = {
+            "readonly_dc": "yes",
+            "something_else": "for_fun",
+        }
+        m_srv2["ansible_inventory"] = {
+            "no_ca": "yes",
+            "something_else": "for_fun",
+        }
+
+        config = provisioning_config()
+        db = get_db_from_metadata(metadata)
+        ans_inv = AnsibleInventoryOutput(config, db, metadata)
+        inventory = ans_inv.create_inventory()
+
+        srv1 = inventory["all"]["hosts"]["srv1.example.test"]
+
+        assert "readonly_dc" in srv1
+        assert srv1["readonly_dc"] == "yes"
+        assert "something_else" in srv1
+        assert srv1["something_else"] == "for_fun"
+
+        srv2 = inventory["all"]["hosts"]["srv2.example.test"]
+        assert "no_ca" in srv2
+        assert "something_else" in srv2
+        assert srv2["no_ca"] == "yes"
+        assert srv2["something_else"] == "for_fun"

--- a/tests/unit/test_pytest_multihost.py
+++ b/tests/unit/test_pytest_multihost.py
@@ -1,0 +1,41 @@
+from mrack.outputs.pytest_multihost import PytestMultihostOutput
+
+from .mock_data import get_db_from_metadata, metadata_extra, provisioning_config
+
+
+class TestPytestMultihostOutput:
+    def test_arbitrary_attrs(self):
+        """
+        Test that values defined in `pytest_multihost` dictionary in host part
+        of job metadata file gets into host attributes in generated pytest-multihost
+        output.
+        """
+        metadata = metadata_extra()
+        m_srv1 = metadata["domains"][0]["hosts"][0]
+        m_srv2 = metadata["domains"][0]["hosts"][1]
+        m_srv1["pytest_multihost"] = {
+            "readonly_dc": "yes",
+            "something_else": "for_fun",
+        }
+        m_srv2["pytest_multihost"] = {
+            "no_ca": "yes",
+            "something_else": "for_fun",
+        }
+
+        config = provisioning_config()
+        db = get_db_from_metadata(metadata)
+        mhcfg_output = PytestMultihostOutput(config, db, metadata)
+        mhcfg = mhcfg_output.create_multihost_config()
+
+        srv1 = mhcfg["domains"][0]["hosts"][0]
+
+        assert "readonly_dc" in srv1
+        assert srv1["readonly_dc"] == "yes"
+        assert "something_else" in srv1
+        assert srv1["something_else"] == "for_fun"
+
+        srv2 = mhcfg["domains"][0]["hosts"][1]
+        assert "no_ca" in srv2
+        assert "something_else" in srv2
+        assert srv2["no_ca"] == "yes"
+        assert srv2["something_else"] == "for_fun"


### PR DESCRIPTION
Make it possible to define arbitratry attributes prefix with meta_
in host section of job metadata file.

All of these attributes are then copied to host part in ansible
inventory output.

It can serve for creation of playbooks which consumes these attributes.

Addtional, but probably rare use case, is to override the meta_ attrs
which are derived from other others by mrack.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>