### PR TITLE
chore: Use python-version 3.9 and bump python-semantic-release for the release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -18,7 +18,7 @@ jobs:
     name: run tox tests
     runs-on: ubuntu-latest
     steps:
-      - name: Install krb5-config libvirt-dev # missing distro dependencies
+      - name: Install krb5-config libvirt-dev  # missing distro dependencies
         run: sudo apt update && sudo apt-get install libkrb5-dev libvirt-dev
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -36,6 +36,11 @@ jobs:
     needs: [pre-commit, test]
     if: github.repository == 'neoave/mrack'
     steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Display Python version
+        run: python --version
       - name: Set up changelog date to use later
         run: echo "TODAY=`date "+%a %b %d %Y"`" >> ${GITHUB_ENV}
       - name: Set RELEASE_ACTOR
@@ -51,7 +56,7 @@ jobs:
           fetch-depth: 0
       - name: Get the new version using python-semantic-releaseq
         run: |
-          pip3 install python-semantic-release==7.15.0
+          pip3 install python-semantic-release==7.30.1
           echo "NEW_VERSION="`semantic-release print-version --noop` >> ${GITHUB_ENV}
       - name: Update the mrack.spec changelog with initiator and basic message
         run: |
@@ -62,7 +67,7 @@ jobs:
       - name: Add specfile to commit
         run: git add mrack.spec
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.15.0
+        uses: relekang/python-semantic-release@v7.30.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>