### PR TITLE
feat(Beaker): Support custom configurable ks_meta values

### DIFF
--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -102,6 +102,10 @@ beaker:  # beaker provider specific values
         default: Server
         CentOS-Stream-9%: BaseOS
 
+    kickstart_metadata:
+        default: ""
+        fedora-37: "harness='restraint-rhts beakerlib-redhat'"
+
     # example of beaker requirement tags for specific distributuions
     distro_tags:
         CentOS-Stream-9%:

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -180,7 +180,7 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
 
         # Recipe task definition
         specs.update(
-            {  # we use dummy task because beaker reuire a task in recipe
+            {  # we use dummy task because beaker require a task in recipe
                 "tasks": [{"name": "/distribution/dummy", "role": "STANDALONE"}]
             }
         )

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -175,9 +175,6 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
         # Add allowed keys
         specs.update({"ks_append": self._allow_ssh_key(self.pubkey)})
 
-        # Use ks_meta
-        specs.update({"ks_meta": "harness='restraint-rhts beakerlib-redhat'"})
-
         # Recipe task definition
         specs.update(
             {  # we use dummy task because beaker require a task in recipe

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -66,6 +66,25 @@ class BeakerTransformer(Transformer):
 
         return (required_distro, variant)
 
+    def _get_ks_meta(self, host):
+        """
+        Get `ks_meta` value from host or provisioning config or default if not defined.
+
+        The priority is following:
+            - host
+            - provisioning-config.yaml
+            - default from provisioning config
+            - empty if not defined in provisioning config
+
+        """
+        res = self._find_value(
+            host.get(CONFIG_KEY, {}),
+            "ks_meta",
+            "kickstart_metadata",
+            host["os"],
+        )
+        return res
+
     def create_host_requirement(self, host):
         """Create single input for Beaker provisioner."""
         distro, variant = self._get_distro_and_variant(host)
@@ -77,5 +96,6 @@ class BeakerTransformer(Transformer):
             "meta_distro": "distro" in host,
             "arch": host.get("arch", "x86_64"),
             "variant": variant,
+            "ks_meta": self._get_ks_meta(host),
             f"mrack_{CONFIG_KEY}": host.get(CONFIG_KEY, {}),
         }

--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -207,7 +207,11 @@ def provisioning_config(inventory_layout=None):
             },
             "pubkey": "config/id_rsa.pub",
             "reserve_duration": 86400,
-            "max_attempts": 240,
+            "kickstart_metadata": {
+                "default": "PROV_CONF_DEFAULT",
+                "rhel-8.6": "PROV_CONF_RHEL86_KS_META",
+                "c9s": "PROV_CONF_CENTOS_KS_META",
+            },
             "timeout": 120,
         },
         "users": {

--- a/tests/unit/test_beaker_transformer.py
+++ b/tests/unit/test_beaker_transformer.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mrack.context import global_context
 from mrack.providers import providers
 from mrack.providers.beaker import PROVISIONER_KEY as BEAKER
 from mrack.providers.beaker import BeakerProvider
@@ -73,6 +74,7 @@ class TestBeakerTransformer:
         providers.register(BEAKER, BeakerProvider)
         res = MockedBeakerTransformer()
         config = provisioning_config()
+        global_context.provisioning_config = config
         if legacy:
             del config["beaker"]["distro_variants"]
 


### PR DESCRIPTION
get the ks_meta from host configuration, global
provisioning config or default hardcoded in code.
The priority is following:
 - host
 - provisioning-config.yaml
 - default (if nothing set)
https://beaker-project.org/docs/user-guide/customizing-installation.html#kickstart-metadata-ks-meta