### PR TITLE
refactor(beaker): move distro_tags and hostRequires to transformer

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -28,7 +28,6 @@ from bkr.client import BeakerJob, BeakerRecipe, BeakerRecipeSet
 from bkr.common.hub import HubProxy
 from bkr.common.pyconfig import PyConfigParser
 
-from mrack.context import global_context
 from mrack.errors import ProvisioningError, ValidationError
 from mrack.host import (
     STATUS_ACTIVE,
@@ -155,11 +154,7 @@ class BeakerProvider(Provider):
         arch_node.setAttribute("value", specs["arch"])
         recipe.addDistroRequires(arch_node)
 
-        host_requires = global_context.PROV_CONFIG[PROVISIONER_KEY].get(
-            "hostRequires",
-            specs.get(f"mrack_{PROVISIONER_KEY}", {}).get("hostRequires", {}),
-        )
-
+        host_requires = specs.get("hostRequires")
         if host_requires:  # suppose to be dict like {"or": [dict()], "and": [dict()]}
             for operand, operand_value in host_requires.items():
                 if operand.startswith("_"):
@@ -178,9 +173,9 @@ class BeakerProvider(Provider):
                 )
 
         # Specify the custom xml distro_tag node with values from provisioning config
-        distro_tags = global_context.PROV_CONFIG["beaker"].get("distro_tags")
+        distro_tags = specs.get("distro_tags")
         if distro_tags:
-            for tag in distro_tags.get(specs["distro"], []):
+            for tag in distro_tags:
                 tag_node = xml_doc().createElement("distro_tag")
                 tag_node.setAttribute("op", "=")
                 tag_node.setAttribute("value", tag)

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -194,7 +194,21 @@ class BeakerTransformer(Transformer):
                 ),
                 self._get_pubkeys(host),
             ),
-            f"mrack_{CONFIG_KEY}": host.get(CONFIG_KEY, {}),
+            # TODO: should have similar logic as _get_flavor
+            "hostRequires": self._find_value(
+                host.get(CONFIG_KEY, {}),
+                "hostRequires",
+                "hostRequires",
+                host["group"],
+                default=None,
+            ),
+            "distro_tags": self._find_value(
+                host.get(CONFIG_KEY, {}),
+                "distro_tags",
+                "distro_tags",
+                distro,
+                default=[],
+            ),
         }
 
         return specs

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -69,6 +69,9 @@ def get_value_or_dict_value(config_dict, attr, dict_name, key):
             value = get_config_value(value_dict, key)
             if value:
                 return value
+        # avoid to return the whole value_dict if dict name is the same as attr
+        if attr == dict_name:
+            return None
 
     value = config_dict.get(attr)
     return value

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -89,10 +89,39 @@ def aws_config():
 
 
 @pytest.fixture
-def provisioning_config(openstack_config, aws_config):
+def beaker_config():
+    return {
+        "strategy": "abort",
+        "distros": {
+            "rhel-8.5": "RHEL-8.5%",
+            "fedora-34": "Fedora-34%",
+        },
+        "distro_variants": {
+            "default": "BaseeOS",
+            "RHEL-7.9%": "Server",
+            "Fedora-34%": "Server",
+        },
+        "distro_tags": {
+            "RHEL-9.0%": "CTS_NIGHTLY",
+        },
+        "pubkey": "config/id_rsa.pub",
+        "reserve_duration": 86400,
+        "timeout:": 230,
+        "flavors": {
+            "ipaserver": "test.medium",
+            "ipaclient": "test.micro",
+            "ad": "test.medium",
+            "default": "test.nano",
+        },
+    }
+
+
+@pytest.fixture
+def provisioning_config(openstack_config, aws_config, beaker_config):
     raw = {
         "openstack": openstack_config,
         "aws": aws_config,
+        "beaker": beaker_config,
         "users": {
             "rhel-8.5": "cloud-user",
             "fedora-34": "fedora",

--- a/tests/unit/test_config_search.py
+++ b/tests/unit/test_config_search.py
@@ -53,6 +53,31 @@ def test_find_value_in_config_hierarchy(
     )
     assert value == "Administrator"
 
+    # Check that dictionary is not returned if dict name is the same as attr and
+    # the dict doesn't have the value for given key
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "beaker",
+        metahost1,
+        host1_osp,
+        "distro_tags",
+        "distro_tags",
+        "RHEL-8.5%",
+    )
+    assert value is None
+
+    # Check that finding value when dict name is the same as attr works
+    value = find_value_in_config_hierarchy(
+        provisioning_config,
+        "beaker",
+        metahost1,
+        host1_osp,
+        "distro_tags",
+        "distro_tags",
+        "RHEL-9.0%",
+    )
+    assert value == "CTS_NIGHTLY"
+
 
 def test_find_simple_value_in_hierarchy(
     provisioning_config, host1_aws, metahost1, host_win_aws, metahost_win


### PR DESCRIPTION
**refactor(beaker): move distro_tags and hostRequires to transformer**

From provider as transformer is the component which should work with
provisioning config.

Also remove the mrack_beaker from specs as it is no longer needed.

**fix: issue when searching for value when dict_name == attr**

When searching for value using find_value_in_config_hierarchy the method
might return the entire dictionary with name according to dict_name when
the search attribute name is the same as dict_name and the dict doesn't have
a default value nor value according to provided key.