### PR TITLE
feat: Split mrack into multiple rpms

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,36 @@ pip install mrack
 It is also available for Fedora 32+ via [COPR](https://copr.fedorainfracloud.org/coprs/g/freeipa/neoave/package/mrack/):
 
 ```
+# enable the copr at your system
 sudo dnf copr enable @freeipa/neoave
+
+# install mrack package with all supported providers and cli
 sudo dnf install mrack
+
+# install mrack command and e.g. AWS provider
+sudo dnf install mrack-cli python3-mrack-aws
+
+# install mrack library to be later used as an import with support of OpenStack provider:
+sudo dnf install python3-mrack-openstack
+
 ```
+---
+**NOTE**
+
+Above command will install `mrack` package which depends on (contains) following packages:
+- mrack-cli
+- python3-mracklib
+- python3-mrack-aws
+- python3-mrack-beaker
+- python3-mrack-openstack
+- python3-mrack-podman
+- python3-mrack-virt
+
+The `python3-mracklib` is mandatory as it contains core mrack library.
+To install only some of `mrack` providers you should install `python3-mrack-{provider_name}`.
+To install mrack command a package `mrack-cli` is required.
+
+---
 
 ## Run mrack
 

--- a/mrack.spec
+++ b/mrack.spec
@@ -1,46 +1,103 @@
 # Created by pyp2rpm-3.3.5
-%global srcname mrack
-
-Name:           %{srcname}
+Name:           mrack
 Version:        1.8.1
 Release:        1%{?dist}
 Summary:        Multicloud use-case based multihost async provisioner for CIs and testing during development
 
 License:        Apache License 2.0
 URL:            https://github.com/neoave/mrack
-Source0:        https://github.com/neoave/mrack/releases/download/v%{version}/mrack-%{version}.tar.gz
+Source0:        https://github.com/neoave/mrack/releases/download/v%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
-BuildRequires:  python3-AsyncOpenStackClient
-BuildRequires:  beaker-client
-BuildRequires:  python3-boto3
-BuildRequires:  python3-botocore
 BuildRequires:  python3-click
 BuildRequires:  python3-pyyaml
 BuildRequires:  python3-setuptools
 
+# coma separated list of provider plugins
+%global provider_plugins aws,beaker,openstack,podman,virt
+
+Requires:       %{name}-cli == %{version}-%{release}
+Requires:       python3-%{name}lib == %{version}-%{release}
+Requires:       python3-%{name}-aws == %{version}-%{release}
+Requires:       python3-%{name}-beaker == %{version}-%{release}
+Requires:       python3-%{name}-openstack == %{version}-%{release}
+Requires:       python3-%{name}-podman == %{version}-%{release}
+Requires:       python3-%{name}-virt == %{version}-%{release}
+
+# We filter out the asyncopenstackclient dependency of this package
+# so it is not forcing installation of missing dependencies in Fedora
+# Once python3-AsyncOpenStackClient is in fedora we can drop this line
+%global __requires_exclude asyncopenstackclient
+
 %description
-mrack is a provisioning library for CI and local multi-host testing supporting multiple
-provisioning providers (e.g. OpenStack, Beaker). But in comparison to other multi-cloud
-libraries, the aim is to be able to describe host from application perspective.
+mrack is a provisioning tool and a library for CI and local multi-host testing supporting
+multiple provisioning providers (e.g. AWS, Beaker, Openstack). But in comparison to other
+multi-cloud libraries, the aim is to be able to describe host from application perspective.
 
-%{?python_provide:%python_provide %{srcname}}
+%{?python_provide:%python_provide %{name}}
 
-Requires:       python3-AsyncOpenStackClient
-Requires:       beaker-client
-Requires:       podman
-Requires:       python3-boto3
-Requires:       python3-botocore
+%package        cli
+Summary:        mrack command
+Requires:       python3-%{name}lib == %{version}-%{release}
+
+%package -n     python3-%{name}lib
+Summary:        Core mrack libraries
 Requires:       python3-click
 Requires:       python3-pyyaml
-Requires:       testcloud
 Requires:       sshpass
 
+%package -n     python3-%{name}-aws
+Summary:        AWS provider plugin for mrack
+Requires:       python3-%{name}lib == %{version}-%{release}
+Requires:       python3-boto3
+Requires:       python3-botocore
+
+%package -n     python3-%{name}-beaker
+Summary:        Beaker provider plugin for mrack
+Requires:       python3-%{name}lib == %{version}-%{release}
+Requires:       beaker-client
+
+%package -n     python3-%{name}-openstack
+Summary:        Openstack provider plugin for mrack
+Requires:       python3-%{name}lib == %{version}-%{release}
+Recommends:     python3-AsyncOpenStackClient
+
+%package -n     python3-%{name}-podman
+Summary:        Podman provider plugin for mrack
+Requires:       python3-%{name}lib == %{version}-%{release}
+Requires:       podman
+
+%package -n     python3-%{name}-virt
+Summary:        Virtualization provider plugin for mrack using testcloud
+Requires:       python3-%{name}lib == %{version}-%{release}
+Requires:       testcloud
+
+%description        cli
+%{name}-cli contains mrack command which functionality can be extended by installing mrack plugins
+
+%description -n     python3-%{name}lib
+python3-%{name}lib contains core mrack functionalities and static provider which can be used as a library
+
+%description -n     python3-%{name}-aws
+%{name}-aws is an additional plugin with AWS provisioning library extending mrack package
+
+%description -n     python3-%{name}-beaker
+%{name}-beaker is an additional plugin with Beaker provisioning library extending mrack package
+
+%description -n     python3-%{name}-openstack
+%{name}-openstack is an additional plugin with OpenStack provisioning library extending mrack package
+
+%description -n     python3-%{name}-podman
+%{name}-podman is an additional plugin with Podman provisioning library extending mrack package
+
+%description -n     python3-%{name}-virt
+%{name}-virt is an additional plugin with Virualization provisioning library extending mrack package using testcloud
+
 %prep
-%autosetup -n %{srcname}-%{version}
+%autosetup -p1 -n %{name}-%{version}
 # Remove bundled egg-info
-rm -rf %{srcname}.egg-info
+rm -rf %{name}.egg-info
 
 %build
 %py3_build
@@ -48,12 +105,44 @@ rm -rf %{srcname}.egg-info
 %install
 %py3_install
 
-%files -n %{srcname}
+%files
 %license LICENSE
 %doc README.md
-%{_bindir}/mrack
-%{python3_sitelib}/%{srcname}
-%{python3_sitelib}/%{srcname}-%{version}-py%{python3_version}.egg-info
+
+%files cli
+%license LICENSE
+%doc README.md
+%{_bindir}/%{name}
+
+%files -n python3-%{name}lib
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{name}
+%{python3_sitelib}/%{name}-%{version}-py%{python3_version}.egg-info
+%exclude %{python3_sitelib}/%{name}/providers/utils/{,__pycache__/}osapi.py
+%exclude %{python3_sitelib}/%{name}/providers/{,__pycache__/}{%{provider_plugins}}.*
+%exclude %{python3_sitelib}/%{name}/transformers/{,__pycache__/}{%{provider_plugins}}.*
+
+%files -n python3-%{name}-aws
+%{python3_sitelib}/%{name}/providers/{,__pycache__/}aws.*
+%{python3_sitelib}/%{name}/transformers/{,__pycache__/}aws.*
+
+%files -n python3-%{name}-beaker
+%{python3_sitelib}/%{name}/providers/{,__pycache__/}beaker.*
+%{python3_sitelib}/%{name}/transformers/{,__pycache__/}beaker.*
+
+%files -n python3-%{name}-openstack
+%{python3_sitelib}/%{name}/providers/utils/{,__pycache__/}osapi.py
+%{python3_sitelib}/%{name}/providers/{,__pycache__/}openstack.*
+%{python3_sitelib}/%{name}/transformers/{,__pycache__/}openstack.*
+
+%files -n python3-%{name}-podman
+%{python3_sitelib}/%{name}/providers/{,__pycache__/}podman.*
+%{python3_sitelib}/%{name}/transformers/{,__pycache__/}podman.*
+
+%files -n python3-%{name}-virt
+%{python3_sitelib}/%{name}/providers/{,__pycache__/}virt.*
+%{python3_sitelib}/%{name}/transformers/{,__pycache__/}virt.*
 
 %changelog
 * Mon Oct 10 2022 Tibor Dudlák <tdudlak@redhat.com> - 1.8.1-1


### PR DESCRIPTION
    Splitting mrack to:
    - mrack
    - mrack-cli
    - python3-mracklib
    - python3-mrack-aws
    - python3-mrack-beaker
    - python3-mrack-openstack
    - python3-mrack-podman
    - python3-mrack-virt
   
    where python3-mracklib contains only static provider and all the
    scripts and provisioning base logic.
    we can install mrack-{aws,beaker,openstack,podman,virt}
    providers in addition to static provider extending
    the functionality and create modular solution where only
    needed providers can be installed.
    Package mrack contains all supported providers.
    Package mrack-cli contains mrack command.
    We are using Suggests directives for OpenStack dependencies
    so in fedora where these are not available build will pass.

Resolves: https://github.com/neoave/mrack/issues/113 

This MR depends on:
- [x] https://github.com/neoave/mrack/pull/191 
- [x] https://github.com/neoave/mrack/pull/194 
- [x] discuss the pacakge division