### PR TITLE
feat(pytest-multihost): Allow extended host config to be passed from …

### DIFF
--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -67,6 +67,7 @@ class PytestMultihostOutput:
             "username",
             "password",
             "host_type",
+            "config",
         ]
 
         # Use values from provisioning-config mhcfg section - as default values


### PR DESCRIPTION
…metadata.

Extended host configuration under "config" is needed for framework build upon pytest multihost https://github.com/pbrezina/sssd-tests-poc