### PR TITLE
chore: bump versions of GitHub actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,8 +10,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -8,11 +8,11 @@ jobs:
     name: run pre-commit hook
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.0
 
   test:
     name: run tox tests
@@ -20,9 +20,9 @@ jobs:
     steps:
       - name: Install krb5-config libvirt-dev  # missing distro dependencies
         run: sudo apt update && sudo apt-get install libkrb5-dev libvirt-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install Tox and any other packages
@@ -36,7 +36,7 @@ jobs:
     needs: [pre-commit, test]
     if: github.repository == 'neoave/mrack'
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Display Python version
@@ -52,12 +52,12 @@ jobs:
         run: |
           RELEASE_ACTOR=RELEASE_ACTOR_$(echo ${GITHUB_ACTOR^^} | tr - _)
           echo "RELEASE_ACTOR=${!RELEASE_ACTOR}" >> ${GITHUB_ENV}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Get the new version using python-semantic-releaseq
         run: |
-          pip3 install python-semantic-release==7.30.1
+          pip3 install python-semantic-release==7.32.2
           echo "NEW_VERSION="`semantic-release print-version --noop` >> ${GITHUB_ENV}
       - name: Update the mrack.spec changelog with initiator and basic message
         run: |
@@ -68,7 +68,7 @@ jobs:
       - name: Add specfile to commit
         run: git add mrack.spec
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.30.1
+        uses: relekang/python-semantic-release@v7.32.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Trying to fix this warning by usage of latest-greatest actions:

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, pre-commit/action, actions/setup-python, actions/checkout

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>