### PR TITLE
fix: add the encoding to multipple open function calls 

### DIFF
--- a/src/mrack/actions/etchosts.py
+++ b/src/mrack/actions/etchosts.py
@@ -33,7 +33,7 @@ class EtcHostsUpdater:
     def __init__(self, path="/etc/hosts"):
         """Init the updater."""
         self.path = path
-        with open(self.path, "r") as etc_hosts:
+        with open(self.path, "r", encoding="utf-8") as etc_hosts:
             self.lines = etc_hosts.readlines()
 
         # Trigger validation
@@ -106,7 +106,7 @@ class EtcHostsUpdater:
     def save(self):
         """Save changes into /etc/hosts."""
         try:
-            with open(self.path, "w") as etc_file:
+            with open(self.path, "w", encoding="utf-8") as etc_file:
                 etc_file.writelines(self.lines)
         except PermissionError as perm_err:
             name = getpass.getuser()

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -193,7 +193,7 @@ class PodmanProvider(Provider):
 
         logger.debug(f"{log_msg_start} Resource: {object2json(server)}")
 
-        with open(os.path.expanduser(self.ssh_key), "r") as key_file:
+        with open(os.path.expanduser(self.ssh_key), "r", encoding="utf-8") as key_file:
             key_content = key_file.read()
 
         if not await self.podman.exec_command(cont_id, "mkdir -p /root/.ssh/"):

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -106,7 +106,7 @@ class BeakerTransformer(Transformer):
         keys_content.append("# keys added by mrack:")
 
         for key in set(pubkeys):
-            with open(os.path.expanduser(key), "r") as key_file:
+            with open(os.path.expanduser(key), "r", encoding="utf-8") as key_file:
                 keys_content.append(f"{key_file.read().strip()}")
 
         keys_content.append("# end section of keys added by mrack")

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -169,14 +169,14 @@ def json_convertor(obj):
 
 def load_json(path):
     """Load JSON file into Python object."""
-    with open(os.path.expanduser(path), "r") as file_data:
+    with open(os.path.expanduser(path), "r", encoding="utf-8") as file_data:
         data = json.load(file_data)
     return data
 
 
 def load_yaml(path):
     """Load YAML file into Python object."""
-    with open(os.path.expanduser(path), "r") as file_data:
+    with open(os.path.expanduser(path), "r", encoding="utf-8") as file_data:
         data = yaml.safe_load(file_data)
     return data
 
@@ -184,7 +184,7 @@ def load_yaml(path):
 def save_to_json(path, data):
     """Serialize object into JSON file."""
     try:
-        with open(os.path.expanduser(path), "w") as output:
+        with open(os.path.expanduser(path), "w", encoding="utf-8") as output:
             json.dump(data, output, default=json_convertor, indent=2, sort_keys=True)
     except IOError as exc:
         logger.exception(exc)
@@ -195,7 +195,7 @@ def save_to_json(path, data):
 def fd_open(filename=None):
     """Use file or stout as output file descriptor."""
     if filename:
-        file_d = open(os.path.expanduser(filename), "w")
+        file_d = open(os.path.expanduser(filename), "w", encoding="utf-8")
     else:
         file_d = sys.stdout
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -10,7 +10,7 @@ def test_dir_path():
 
 def get_data(name, data_dir="data"):
     path = os.path.join(test_dir_path(), data_dir, name)
-    with open(os.path.expanduser(path), "r") as file_data:
+    with open(os.path.expanduser(path), "r", encoding="utf-8") as file_data:
         data = json.load(file_data)
     return data
 


### PR DESCRIPTION
pylint started to complain about unspecified encoding, thus adding to open functions.