### PR TITLE
fix: mrack spec fix, tox update and import fix

### DIFF
--- a/mrack.spec
+++ b/mrack.spec
@@ -35,8 +35,6 @@ testing supporting multiple provisioning providers (e.g. AWS, Beaker,
 Openstack). But in comparison to other multi-cloud libraries,
 the aim is to be able to describe host from application perspective.
 
-%{?python_provide:%python_provide %{name}}
-
 %package        cli
 Summary:        Command line interface for mrack
 Requires:       python3-%{name}lib = %{version}-%{release}

--- a/mrack.spec
+++ b/mrack.spec
@@ -38,10 +38,10 @@ the aim is to be able to describe host from application perspective.
 %package        cli
 Summary:        Command line interface for mrack
 Requires:       python3-%{name}lib = %{version}-%{release}
+Requires:       python3-click
 
 %package -n     python3-%{name}lib
 Summary:        Core mrack libraries
-Requires:       python3-click
 Requires:       python3-pyyaml
 Requires:       sshpass
 
@@ -136,6 +136,7 @@ rm -rf %{name}.egg-info
 %doc README.md
 %doc CHANGELOG.md
 %{_bindir}/%{name}
+%{python3_sitelib}/%{name}/{,__pycache__/}run.*
 
 %files -n python3-%{name}lib
 %license LICENSE
@@ -143,6 +144,7 @@ rm -rf %{name}.egg-info
 %doc CHANGELOG.md
 %{python3_sitelib}/%{name}
 %{python3_sitelib}/%{name}-%{version}-py%{python3_version}.egg-info
+%exclude %{python3_sitelib}/%{name}/{,__pycache__/}run.*
 %exclude %{python3_sitelib}/%{name}/providers/utils/{,__pycache__/}osapi.*
 %exclude %{python3_sitelib}/%{name}/providers/utils/{,__pycache__/}testcloud.*
 %exclude %{python3_sitelib}/%{name}/providers/utils/{,__pycache__/}podman.*

--- a/mrack.spec
+++ b/mrack.spec
@@ -117,7 +117,7 @@ library extending mrack package using testcloud
 %prep
 %autosetup -p1 -n %{name}-%{version}
 # Remove bundled egg-info
-rm -rf %{name}.egg-info
+rm -r src/%{name}.egg-info
 
 %build
 %py3_build

--- a/src/mrack/actions/ssh.py
+++ b/src/mrack/actions/ssh.py
@@ -20,9 +20,13 @@ from mrack.actions.action import Action
 from mrack.context import global_context
 from mrack.errors import ApplicationError
 from mrack.host import STATUS_ACTIVE
-from mrack.providers.utils.podman import Podman
 from mrack.utils import get_username_pass_and_ssh_key
 from mrack.utils import ssh_to_host as utils_ssh_to_host
+
+try:
+    from mrack.providers.utils.podman import Podman
+except ModuleNotFoundError:
+    pass  # Ignore the module import error if plugin not available
 
 logger = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ deps =
     sphinx
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-basepython = python3.7
+basepython = python3.9


### PR DESCRIPTION
fix(Podman): Fix action ssh import failing if podman provider not found
    
    When podman provider is not installed as plugin
    we should not import it in ssh.
    Ignoring the import error will fix tracebacks.


chore: bump python version in tox.ini
    
    In our automation we rely on python 3.9
    setting tox.ini to same version
    
fix(mrack.spec): remove unecessary statement
    
    the python_provide should be used
    for python*- packages only thus removing.
    
fix(mrack.spec): cli package files and deps
    
    Fixing the cli package dependency by adding
    the Requires: python3-click and removing
    unnecessary file run.py from lib package
    and move it to cli package where it belongs

