### PR TITLE
feat(openstack-aws): Add owner/lifetime info in VM's metadata

### DIFF
--- a/mrack.spec
+++ b/mrack.spec
@@ -44,6 +44,7 @@ Requires:       python3-click
 %package -n     python3-%{name}lib
 Summary:        Core mrack libraries
 Requires:       python3-pyyaml
+Recommends:     python3-gssapi
 Requires:       sshpass
 
 %{?python_provide:%python_provide python3-%{name}lib}

--- a/setup.py
+++ b/setup.py
@@ -54,4 +54,7 @@ setup(
     package_data={
         "mrack": [f"data/{datafile}" for datafile in [MRACK_CONF, PROV_CONF]]
     },
+    extras_require={
+        "krb-owner": ["gssapi"],
+    },
 )

--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -137,3 +137,7 @@ class MrackConfig:
     def pytest_multihost_path(self, default=None):
         """Return configured path to pytest-multihost configuration output."""
         return self.get("pytest-multihost", default)
+
+    def require_owner(self, default=False):
+        """Return value of require-owner."""
+        return bool(self.get("require-owner", default))

--- a/src/mrack/data/mrack.conf
+++ b/src/mrack/data/mrack.conf
@@ -4,3 +4,4 @@ provisioning-config = provisioning-config.yaml
 metadata = metadata.yaml
 ansible-inventory = mrack-inventory.yaml
 pytest-multihost = pytest-multihost.yaml
+require-owner = False

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -329,6 +329,10 @@ class AWSProvider(Provider):
         for key, value in self.instance_tags.items():
             taglist.append({"Key": key, "Value": value})
 
+        if specs.get("metadata"):
+            for key, value in specs.get("metadata").items():
+                taglist.append({"Key": key, "Value": value})
+
         logger.debug(f"{log_msg_start} Tagging instance with: {object2json(taglist)}")
 
         request = {

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -107,4 +107,5 @@ class AWSTransformer(Transformer):
             "subnet_ids": self._find_subnet_ids(host),
         }
 
+        req = self.update_metadata_for_owner_lifetime(req)
         return req

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -76,4 +76,5 @@ class OpenStackTransformer(Transformer):
         if config_drive_req:
             req.update({"config_drive": config_drive_req})
 
+        req = self.update_metadata_for_owner_lifetime(req)
         return req

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,6 +21,11 @@ def provisioning_config(datadir):
 
 
 @pytest.fixture()
+def provisioning_config_file(datadir):
+    return os.path.join(datadir, "provisioning-config.yaml")
+
+
+@pytest.fixture()
 def metadata(datadir):
     data = (datadir / "metadata-hosts.yaml").read_text()
     return yaml.safe_load(data)

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -6,6 +6,7 @@ from mrack.actions.destroy import Destroy as DestroyAction
 from mrack.actions.list import List as ListAction
 from mrack.actions.output import Output as OutputAction
 from mrack.actions.up import Up as UpAction
+from mrack.context import global_context
 from mrack.host import STATUS_ACTIVE, STATUS_DELETED
 from mrack.providers import aws, openstack, providers, static
 
@@ -15,6 +16,11 @@ def setup_providers():
     providers.register(aws.PROVISIONER_KEY, aws.AWSProvider)
     providers.register(openstack.PROVISIONER_KEY, openstack.OpenStackProvider)
     providers.register(static.PROVISIONER_KEY, static.StaticProvider)
+
+
+@pytest.fixture(autouse=True)
+def global_context_init(provisioning_config_file, mrack_config_file=None, db_file=None):
+    global_context.init(mrack_config_file, provisioning_config_file, db_file)
 
 
 class TestStaticProvider:


### PR DESCRIPTION
Owner and lifetime info will be added into VM's metadata for Openstack/AWS providers. This info will give info who owns the VM and what is the lifetime of the VM which will be used for notifying owners and cleaning up the resources based on lifetime of the VMs.
If owner info not fetched, user notified with custom error message for follow up action to take up.

Signed-off-by: ksiddiqu <ksiddiqu@redhat.com>