### PR TITLE
chore: disable automatic runtime deps discovery for rpm build

### DIFF
--- a/mrack.spec
+++ b/mrack.spec
@@ -28,6 +28,7 @@ Requires:       python3-%{name}-virt = %{version}-%{release}
 # so it is not forcing installation of missing dependencies in Fedora
 # Once python3-AsyncOpenStackClient is in fedora we can drop this line
 %global __requires_exclude asyncopenstackclient
+%{?python_disable_dependency_generator}
 
 %description
 mrack is a provisioning tool and a library for CI and local multi-host


### PR DESCRIPTION
As it is adding all dependencies to all rpms and ignoring the individual nuaces between packages. I.e. without this, we cannot install python3-mracklib without the rest.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>