### PR TITLE
chore: rpm and clean-rpms targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,19 @@ format:
 
 test:
 	tox
+
+rpms:
+	mkdir -p ~/rpmbuild/SOURCES
+	mkdir -p dist
+	python3 setup.py sdist
+	cp dist/mrack-*.tar.gz ~/rpmbuild/SOURCES/
+	rpmbuild -ba mrack.spec
+	ls ~/rpmbuild/RPMS/noarch
+
+clean-rpms:
+	rm -rf ~/rpmbuild/BUILD/*
+	rm -rf ~/rpmbuild/BUILDROOT/*
+	rm -rf ~/rpmbuild/RPMS/*
+	rm -rf ~/rpmbuild/SOURCES/*
+	rm -rf ~/rpmbuild/SRPMS/*
+	rm -rf ./dist


### PR DESCRIPTION
To make buiding of rpms easier - for adhoc testing/development and sort of work as a documentation how to do it as it is easily forgotten when not doing often.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>