### PR TITLE
fix: Do not use deprecated asyncio.coroutine wrapper

### DIFF
--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -14,10 +14,8 @@
 
 """mrack default app."""
 #  pylint: disable=no-name-in-module
-import asyncio
 import logging
 import sys
-from functools import update_wrapper
 from typing import Set, Tuple, Type
 
 import click
@@ -38,6 +36,7 @@ from mrack.errors import (
 )
 from mrack.providers import providers
 from mrack.providers.provider import Provider
+from mrack.utils import async_run
 from mrack.version import VERSION
 
 PROVIDER_NAME = 0
@@ -94,17 +93,6 @@ try:
     installed_providers.add((VIRT, VirtProvider))
 except ModuleNotFoundError as err:
     logger.debug(IMPORT_ERR_TEMPLATE, err.name)
-
-
-def async_run(func):
-    """Decorate click actions to run as async."""
-    func = asyncio.coroutine(func)
-
-    def wrapper(*args, **kwargs):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(func(*args, **kwargs))
-
-    return update_wrapper(wrapper, func)
 
 
 def init_providers():

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -24,7 +24,7 @@ import logging
 import os
 import subprocess
 import sys
-from functools import update_wrapper
+from functools import wraps
 from xml.dom.minidom import Document as xml_doc
 
 import yaml
@@ -390,13 +390,12 @@ async def exec_async_subprocess(program, args, raise_on_err=True):
 
 def async_run(func):
     """Decorate click actions to run as async."""
-    func = asyncio.coroutine(func)
 
-    def wrapper(*args, **kwargs):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(func(*args, **kwargs))
+    @wraps(func)
+    def update_wrapper(*args, **kwargs):
+        return asyncio.run(func(*args, **kwargs))
 
-    return update_wrapper(wrapper, func)
+    return update_wrapper
 
 
 class NoSuchFileHandler:


### PR DESCRIPTION
Python 3.11.0 completely dropped support for the
asyncio.coroutine. As it was already deprecated
we should use the proper way of decorating the
click functions in the mrack run.py.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>