### PR TITLE
chore: Use personal GH token to release mrack

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Python Semantic Release
         uses: relekang/python-semantic-release@v7.32.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.TIBORIS_GH_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}
       - name: Trigger COPR build
         run: curl -X POST ${{ secrets.COPR_WEBHOOK_URL }}


### PR DESCRIPTION
When branch protection is enabled only real
user (not gh-actions as it is bot) can push
to the main branch when there is Pull Request
required and approvals for particular PR.
With exception added to the users which can bypass the protection rules we should be able to release
with personal GH token generated for the user.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>