### PR TITLE
fix: validate ownership and lifetime only for AWS and OpenStack

### DIFF
--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -90,6 +90,11 @@ class AWSTransformer(Transformer):
 
         return []
 
+    def validate_host(self, host):
+        """Validate host input that it contains what AWS needs."""
+        super().validate_host(host)
+        self.validate_ownership_and_lifetime(host)
+
     def create_host_requirement(self, host):
         """Create single input for AWS provisioner."""
         del_vol = self._find_value(

--- a/src/mrack/transformers/openstack.py
+++ b/src/mrack/transformers/openstack.py
@@ -59,6 +59,11 @@ class OpenStackTransformer(Transformer):
             )
         return network_type
 
+    def validate_host(self, host):
+        """Validate host input that it contains what OpenStack needs."""
+        super().validate_host(host)
+        self.validate_ownership_and_lifetime(host)
+
     def create_host_requirement(self, host):
         """Create single input for OpenStack provisioner."""
         req = {

--- a/src/mrack/transformers/transformer.py
+++ b/src/mrack/transformers/transformer.py
@@ -143,7 +143,6 @@ class Transformer:
     def validate_host(self, host):
         """Validate host input that it contains everything needed by provider."""
         log_msg_start = f"{self.dsp_name} [{host.get('name')}]"
-        self.validate_ownership_and_lifetime(host)
         # attribute check
         validate_dict_attrs(host, self._required_host_attrs, "host")
         # provider check


### PR DESCRIPTION
Limitin only for certain providers is needed as the owner doesn't matter for static (vm already present somewhere, could be owned by completely different person), podman, libvirst (vm running on current machine, no need for owners).

But it makes sense for any cloud like OpenStack, AWS, Beaker.

Enabled only for AWS, OpenStack as Beaker doesn't work with ownership yet.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>