### PR TITLE
fix: raise Validation error when validation fails and use MrackError

### DIFF
--- a/src/mrack/actions/up.py
+++ b/src/mrack/actions/up.py
@@ -18,7 +18,7 @@ import asyncio
 import logging
 
 from mrack.actions.action import Action
-from mrack.errors import MetadataError, ProvisioningError
+from mrack.errors import MetadataError, MrackError, ProvisioningError
 from mrack.providers import providers
 from mrack.utils import validate_dict_attrs
 
@@ -90,7 +90,7 @@ class Up(Action):
         success_hosts = []
         failed_providers = []
         for results in provisioning_results:
-            if isinstance(results, ProvisioningError):
+            if isinstance(results, MrackError):
                 # in this case some of any provider fails to provision
                 # we need to cleanup all the remaining resources
                 # even when provisioned successfully

--- a/src/mrack/errors.py
+++ b/src/mrack/errors.py
@@ -15,19 +15,25 @@
 """Provisioning errors."""
 
 
-class ConfigError(Exception):
+class MrackError(Exception):
+    """Base mrack error."""
+
+    pass
+
+
+class ConfigError(MrackError):
     """Error in configuration."""
 
     pass
 
 
-class ApplicationError(Exception):
+class ApplicationError(MrackError):
     """General application error."""
 
     pass
 
 
-class MetadataError(Exception):
+class MetadataError(MrackError):
     """Error in job metadata."""
 
     pass
@@ -53,13 +59,13 @@ class JobConfigError(ConfigError):
     pass
 
 
-class ValidationError(Exception):
+class ValidationError(MrackError):
     """Error found in validation of values."""
 
     pass
 
 
-class ProviderError(Exception):
+class ProviderError(MrackError):
     """General provider error."""
 
     pass

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -316,9 +316,10 @@ class OpenStackProvider(Provider):
             usable += low_avail_nets
 
         if not usable:
-            raise ProviderError(
-                f"{self.dsp_name} Error: no available networks"
-                f" for {requested_ip_cnt} hosts with {network_type}"
+            raise ValidationError(
+                "Error: no available networks for "
+                f"{requested_ip_cnt} hosts with {network_type}",
+                self.dsp_name,
             )
 
         if len(usable) > requested_ip_cnt:

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -27,13 +27,7 @@ from mrack.actions.output import Output
 from mrack.actions.ssh import SSH
 from mrack.actions.up import Up
 from mrack.context import GlobalContext, global_context
-from mrack.errors import (
-    ApplicationError,
-    ConfigError,
-    MetadataError,
-    ProviderError,
-    ValidationError,
-)
+from mrack.errors import ApplicationError, MrackError
 from mrack.providers import providers
 from mrack.providers.provider import Provider
 from mrack.utils import async_run
@@ -236,11 +230,7 @@ def exception_handler(func):
             ret_code = func(*args, **kwargs)
         except (
             FileNotFoundError,
-            ConfigError,
-            MetadataError,
-            ValidationError,
-            ProviderError,
-            ApplicationError,
+            MrackError,
         ) as known_error:
             logger.error(known_error)
             sys.exit(1)

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from mrack.errors import ProviderError
+from mrack.errors import MrackError, ValidationError
 from mrack.providers.openstack import OpenStackProvider
 
 from .utils import get_data  # FIXME do not use relative import
@@ -162,7 +162,7 @@ network_data = [
         ],
         net_pools,
         no_usable_traceback_2ips_left,
-        ProviderError("OpenStack Error: no available networks for 3 hosts with IPv4"),
+        ValidationError("OpenStack Error: no available networks for 3 hosts with IPv4"),
     ),
     (
         "test1-host_low-availability_1random_from_all_nets",
@@ -180,7 +180,7 @@ network_data = [
         ],
         net_pools,
         no_usable_traceback_no_ips_left,
-        ProviderError("OpenStack Error: no available networks for 3 hosts with IPv4"),
+        ValidationError("Error: no available networks for 3 hosts with IPv4"),
     ),
 ]
 
@@ -316,8 +316,8 @@ class TestOpenStackProvider:
         await provider.init(image_names=[], networks=pools)
         try:
             provider.translate_network_types(hosts)
-        except ProviderError as no_nets:
-            assert isinstance(exp_nets, ProviderError) is True
+        except MrackError as no_nets:
+            assert isinstance(exp_nets, ValidationError) is True
             assert "no available networks" in str(no_nets)
             assert str(len(hosts)) in str(no_nets)
             return True


### PR DESCRIPTION
This is bit cosmetic change, adding MrackError class which is parent of all errors so later we just catch the MrackError exceptions.