### PR TITLE
chore: change the persist credentials to false and bump commit msg checker version

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -10,7 +10,7 @@ jobs:
   check-commit-message:
     runs-on: ubuntu-latest
     steps:
-      - uses: gsactions/commit-message-checker@v1
+      - uses: gsactions/commit-message-checker@v2
         with:
           pattern: '^(feat|fix|docs|style|refactor|perf|test|chore)(\(.+\))?:\ .+$'
           flags: 'gm'

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -54,6 +54,7 @@ jobs:
           echo "RELEASE_ACTOR=${!RELEASE_ACTOR}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v3
         with:
+          persist-credentials: false  # do not set the actions user to git config
           fetch-depth: 0
       - name: Get the new version using python-semantic-releaseq
         run: |


### PR DESCRIPTION
This will not force the actions user credentials
to be stored into git config which will later
result in using github_token of release actor.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>