### PR TITLE
chore: Add packit service configuration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,48 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+specfile_path: mrack.spec
+
+# add or remove files that should be synced
+files_to_sync:
+  - mrack.spec
+  - README.md
+  - .packit.yaml
+
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_package_name: mrack
+# downstream (Fedora) RPM package name
+downstream_package_name: mrack
+
+actions:
+  create-archive:
+    - "python3 setup.py sdist --dist-dir ."
+    - "sh -c 'echo mrack-$(python3 setup.py --version).tar.gz'"
+  get-current-version:
+    - "python3 setup.py --version"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets: [fedora-all]
+
+  - job: copr_build
+    trigger: release
+    owner: "@freeipa"
+    project: neoave
+    targets: [fedora-all]
+
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-all
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-all
+
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
This commit is enabling packit service for the mrack
project. see: https://packit.dev/docs/configuration/

To start using Packit we did:
- set up integration on GitHub side and selected free plan
- got approved by mapping FAS identity (tdudlak) to the
  service via: https://github.com/packit/notifications/issues/482
  by linking neoave organization with FAS account
- configured the wanted features via this commit

This commit sets up packit jobs to:
- check build per pull request
- trigger copr build after a release
- create fedora PRs to mrack project with updates 
  - rights for packit user for the repo should be added (fedora)
- create koji build per commit merged to fedora's mrack
- create bodhi updates per each successful koji build

This allows us to forget about backporting pathces
to Fedora repo and automate release workflow per
each supported Fedora release currently not EOL.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>