### PR TITLE
fix: make db file and provisioning file optional

### DIFF
--- a/src/mrack/context.py
+++ b/src/mrack/context.py
@@ -52,7 +52,7 @@ class GlobalContext:
         """Get ProvisioningConfig object."""
         return self.metadata
 
-    def init(self, mrack_config, provisioning_config, db_file):
+    def init(self, mrack_config, provisioning_config=None, db_file=None):
         """Initialize Global Context object with all needed values."""
         self._init_mrack_config(mrack_config)
         self.mrack_conf.load()


### PR DESCRIPTION
When initializing the global context these files
should be passed to the init as optional param
when path is specified in mrack cli tool.
Otherwise mrack should only load the data from
the mrack.conf file records and rely on paths
set there for db and provisioning-config.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>