### PR TITLE
chore(Packit): Add upstream_tag_template to .packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,9 @@ files_to_sync:
 upstream_package_name: mrack
 # downstream (Fedora) RPM package name
 downstream_package_name: mrack
+# mrack uses tag v(ver_number) and we need to make sure packit know what to expect
+# see: https://packit.dev/docs/configuration/#upstream_tag_template
+upstream_tag_template: "v{version}"
 
 actions:
   create-archive:


### PR DESCRIPTION
This configuration options sets up the packit tag template for packit to know what tag format to expect when checking the release to properly set the variables for the archives.

Resolves: https://github.com/neoave/mrack/issues/220

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>