### PR TITLE
fix: Owner requirement boolean parsing from string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ multi_line_output = 3
 markers = [
     "etc_hosts: passes path for etc_hosts fixture",
 ]
+pythonpath = [
+  "./src"
+]
 
 [tool.semantic_release]
 version_source = "commit"

--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -22,6 +22,7 @@ import os
 from configparser import ConfigParser, NoOptionError, ParsingError
 
 from mrack.errors import ConfigError
+from mrack.utils import value_to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -140,4 +141,4 @@ class MrackConfig:
 
     def require_owner(self, default=False):
         """Return value of require-owner."""
-        return bool(self.get("require-owner", default))
+        return value_to_bool(self.get("require-owner", default))

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -34,6 +34,27 @@ from mrack.errors import ConfigError, ProvisioningError
 logger = logging.getLogger(__name__)
 
 
+def value_to_bool(value):
+    """Convert Python variable value to boolean."""
+    _false_set = {"no", "false", "f", "n", "0"}
+    _true_set = {"yes", "true", "t", "y", "1"}
+    if isinstance(value, str):
+        if value.lower() in _true_set:
+            return True
+
+        if value.lower() in _false_set:
+            return False
+
+        raise ValueError(
+            f"Invalid input string for boolean conversion '{value}',"
+            "supported values are:\n"
+            f"False:\t{_true_set}\n"
+            f"True:\t{_false_set}"
+        )
+
+    return bool(value)
+
+
 def get_config_value(config_dict, key, default=None):
     """Get configuration value or default value from dictionary.
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,65 +3,70 @@ import pytest
 from mrack.utils import get_shortname, get_username, value_to_bool
 
 
-@pytest.mark.parametrize(
-    "hostname,expected",
-    [
-        ("abc", "abc"),
-        ("foo.bar.baz", "foo"),
-        ("foo.", "foo"),
-        (".", ""),
-    ],
-)
-def test_get_shortname(hostname, expected):
-    assert get_shortname(hostname) == expected
+class TestPytestMrackUtils:
+    @pytest.mark.parametrize(
+        "hostname,expected",
+        [
+            ("abc", "abc"),
+            ("foo.bar.baz", "foo"),
+            ("foo.", "foo"),
+            (".", ""),
+        ],
+    )
+    def test_get_shortname(self, hostname, expected):
+        assert get_shortname(hostname) == expected
 
+    def test_get_username(
+        self,
+        provisioning_config,
+        host1_aws,
+        host1_osp,
+        metahost1,
+        host_win_aws,
+        metahost_win,
+    ):
+        value = get_username(host1_aws, metahost1, provisioning_config)
+        assert value == "ec2-user"
 
-def test_get_username(
-    provisioning_config, host1_aws, host1_osp, metahost1, host_win_aws, metahost_win
-):
-    value = get_username(host1_aws, metahost1, provisioning_config)
-    assert value == "ec2-user"
+        value = get_username(host1_osp, metahost1, provisioning_config)
+        assert value == "cloud-user"
 
-    value = get_username(host1_osp, metahost1, provisioning_config)
-    assert value == "cloud-user"
+        value = get_username(host_win_aws, metahost_win, provisioning_config)
+        assert value == "Administrator"
 
-    value = get_username(host_win_aws, metahost_win, provisioning_config)
-    assert value == "Administrator"
-
-
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        ("true", True),
-        ("True", True),
-        ("t", True),
-        ("T", True),
-        ("TRUe", True),
-        ("trUE", True),
-        ("TRUE", True),
-        ("1", True),
-        ("false", False),
-        ("False", False),
-        ("FALse", False),
-        ("faLSE", False),
-        ("FALSE", False),
-        ("0", False),
-        ([], False),
-        (["ITEM"], True),
-        ({"A": 9}, True),
-        ({}, False),
-        ((), False),
-        ((1, 2), True),
-        (True, True),
-        (False, False),
-        ("foo.true.baz", ValueError),
-        ("abc false", ValueError),
-        ("true9.", ValueError),
-        ("false1", ValueError),
-    ],
-)
-def test_value_to_bool(value, expected):
-    try:
-        assert value_to_bool(value) == expected
-    except Exception as exc:
-        assert isinstance(exc, expected)
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("true", True),
+            ("True", True),
+            ("t", True),
+            ("T", True),
+            ("TRUe", True),
+            ("trUE", True),
+            ("TRUE", True),
+            ("1", True),
+            ("false", False),
+            ("False", False),
+            ("FALse", False),
+            ("faLSE", False),
+            ("FALSE", False),
+            ("0", False),
+            ([], False),
+            (["ITEM"], True),
+            ({"A": 9}, True),
+            ({}, False),
+            ((), False),
+            ((1, 2), True),
+            (True, True),
+            (False, False),
+            ("foo.true.baz", ValueError),
+            ("abc false", ValueError),
+            ("true9.", ValueError),
+            ("false1", ValueError),
+        ],
+    )
+    def test_value_to_bool(self, value, expected):
+        try:
+            assert value_to_bool(value) == expected
+        except Exception as exc:
+            assert isinstance(exc, expected)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mrack.utils import get_shortname, get_username
+from mrack.utils import get_shortname, get_username, value_to_bool
 
 
 @pytest.mark.parametrize(
@@ -27,3 +27,41 @@ def test_get_username(
 
     value = get_username(host_win_aws, metahost_win, provisioning_config)
     assert value == "Administrator"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("t", True),
+        ("T", True),
+        ("TRUe", True),
+        ("trUE", True),
+        ("TRUE", True),
+        ("1", True),
+        ("false", False),
+        ("False", False),
+        ("FALse", False),
+        ("faLSE", False),
+        ("FALSE", False),
+        ("0", False),
+        ([], False),
+        (["ITEM"], True),
+        ({"A": 9}, True),
+        ({}, False),
+        ((), False),
+        ((1, 2), True),
+        (True, True),
+        (False, False),
+        ("foo.true.baz", ValueError),
+        ("abc false", ValueError),
+        ("true9.", ValueError),
+        ("false1", ValueError),
+    ],
+)
+def test_value_to_bool(value, expected):
+    try:
+        assert value_to_bool(value) == expected
+    except Exception as exc:
+        assert isinstance(exc, expected)


### PR DESCRIPTION
When parsing boolean values from string using bool() builtin funtion string which is not empty returns True Writing a util function to convert such strings
to proper boolean values. NOTE: distutil implementation: from distutils.util import strtobool
will be deprecated and removed in future python releases thus implementing a funtion ourselves might be
future proof solution at this time.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>