### PR TITLE
chore: Use python 3.10 in GH actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - uses: pre-commit/action@v3.0.0
 
   test:
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Display Python version
         run: python --version
       - name: Set up changelog date to use later

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 ---
 default_language_version:
-  python: python3.9
+  python: python3.10
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -16,23 +16,23 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.14.0
+    rev: v0.18.0
     hooks:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.25.0
+    rev: v1.28.0
     hooks:
       - id: yamllint
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 5.1.1
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
         files: ^src/.*
 
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         exclude: ^docs/.*
@@ -41,24 +41,23 @@ repos:
         require_serial: true
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.6.4
+    rev: v5.10.1
     hooks:
       - id: isort
         additional_dependencies: [toml]
         exclude: ^docs/.*$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.991
     hooks:
       - id: mypy
         exclude: ^(docs|tests)/.*$
         args: ["--ignore-missing-imports"]
+        additional_dependencies: ["types-PyYAML", "types-python-dateutil"]
 
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.7.4
+    rev: v3.0.0a5
     hooks:
       - id: pylint
         additional_dependencies: ["isort[pyproject]"]
         exclude: ^(docs/|tests/).*$
-        # disabled import-error as may be run out of environment with deps
-        args: ["--disable=import-error"]

--- a/.pylintrc
+++ b/.pylintrc
@@ -12,7 +12,7 @@
 #disable=
 # mrack is starting to use f style strings string-interpolation and have some
 # specific classes which are adding functionality to ones they inherit from
-disable=fixme,too-many-instance-attributes,no-self-use,attribute-defined-outside-init,unnecessary-pass,super-init-not-called,too-many-arguments,too-few-public-methods,logging-fstring-interpolation,
+disable=fixme,too-many-instance-attributes,attribute-defined-outside-init,unnecessary-pass,super-init-not-called,too-many-arguments,too-few-public-methods,logging-fstring-interpolation,import-error
 
 # Minimum lines number of a similarity.
 min-similarity-lines=11

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,8 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    Python39:
-      python.version: '3.9'
+    Python310:
+      python.version: '3.10'
 
 steps:
   - task: UsePythonVersion@0

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -111,7 +111,7 @@ class AnsibleInventoryOutput:
     files and information in DB.
     """
 
-    def __init__(self, config, db, metadata, path=None):
+    def __init__(self, config, db, metadata, path=None):  # pylint: disable=invalid-name
         """Init the output module."""
         self._config = config
         self._db = db
@@ -138,6 +138,7 @@ class AnsibleInventoryOutput:
         dom_name = meta_domain["name"]
 
         # Common attributes
+        dc_list = [f"DC={dc}" for dc in dom_name.split(".")]
         host_info = {
             "ansible_host": ansible_host,
             "ansible_python_interpreter": python,
@@ -148,7 +149,7 @@ class AnsibleInventoryOutput:
             "meta_provider": db_host.provider.name,
             "meta_provider_id": db_host.host_id,
             "meta_ip": ip_addr,
-            "meta_dc_record": ",".join("DC=%s" % dc for dc in dom_name.split(".")),
+            "meta_dc_record": ",".join(dc_list),
         }
 
         if "restraint_id" in meta_host:

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -36,7 +36,7 @@ class PytestMultihostOutput:
     metadata definition.
     """
 
-    def __init__(self, config, db, metadata, path=None):
+    def __init__(self, config, db, metadata, path=None):  # pylint: disable=invalid-name
         """Init the output module."""
         self._config = config
         self._db = db

--- a/src/mrack/providers/__init__.py
+++ b/src/mrack/providers/__init__.py
@@ -26,8 +26,8 @@ class Registry:
 
     def __init__(self):
         """Initialize Registry."""
-        self._provider_cls = dict()
-        self._providers = dict()
+        self._provider_cls = {}
+        self._providers = {}
 
     def register(self, name, provider_cls):
         """Register new provider."""

--- a/src/mrack/transformers/__init__.py
+++ b/src/mrack/transformers/__init__.py
@@ -84,8 +84,8 @@ class Registry:
 
     def __init__(self):
         """Initialize transformer registry."""
-        self._transformer_cls = dict()
-        self._transformers = dict()
+        self._transformer_cls = {}
+        self._transformers = {}
 
     def register(self, name, transformer_cls):
         """Register new tranformer class."""

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -353,8 +353,8 @@ def ssh_to_host(
     cmd = " ".join(cmd)
 
     logger.debug(f"Running: {cmd}")
-    process = subprocess.Popen(cmd, **run_args)
-    std_out, std_err = process.communicate()
+    with subprocess.Popen(cmd, **run_args) as process:
+        std_out, std_err = process.communicate()
 
     if not interactive:
         for o_line in std_out.decode().splitlines():


### PR DESCRIPTION
Using latest python will help us to identify
latest changes and regressions early in upstream PRs. Bumped repo versions in .pre-commit-config.yaml
to point to latest stable releases per available check.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>