### PR TITLE
fix(AWS): refactor sources to be py3.6 compatible and add epels to packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -27,25 +27,22 @@ actions:
 jobs:
   - job: copr_build
     trigger: pull_request
-    targets: [fedora-all]
+    targets: [fedora-all, epel-8, epel-9]
 
   - job: copr_build
     trigger: release
     owner: "@freeipa"
     project: neoave
-    targets: [fedora-all]
+    targets: [fedora-all, epel-8, epel-9]
 
   - job: propose_downstream
     trigger: release
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: [fedora-all, epel-8, epel-9]
 
   - job: koji_build
     trigger: commit
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: [fedora-all, epel-8, epel-9]
 
   - job: bodhi_update
     trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+    dist_git_branches: [fedora-branched, epel-8, epel-9] # rawhide updates are created automatically

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -244,7 +244,8 @@ class AWSProvider(Provider):
         # For all hosts, get subnets in dict (with no repetitions) and list of
         # provided single & multiple subnets
         for host in hosts:
-            if subnet_ids := host.get("subnet_ids"):
+            subnet_ids = host.get("subnet_ids")
+            if subnet_ids:
                 if len(subnet_ids) == 1:
                     single_subnet_prov.append(subnet_ids[0])
                     if subnet_ids[0] not in ip_availabilities:
@@ -353,7 +354,8 @@ class AWSProvider(Provider):
             "TagSpecifications": [{"ResourceType": "instance", "Tags": taglist}],
         }
 
-        if subnet_ids := specs.get("subnet_ids"):
+        subnet_ids = specs.get("subnet_ids")
+        if subnet_ids:
             shuffle(subnet_ids)  # Randomize subnets order
             for subnet_id in subnet_ids:
                 if self.subnets_capacity[subnet_id] > 0:


### PR DESCRIPTION
    chore(Packit): enable epel-8 and epel-9 updates and tests

    fix(AWS): refactor sources to be py3.6 compatible
    
    When considering mrack to be part of
    the tmt which is used even in epel8 and epel9
    we might be limited to not use latest python
    features which one of them is := opearator.