### PR TITLE
fix: Add several c8s fixes for missing deps and decorators

### DIFF
--- a/mrack.spec
+++ b/mrack.spec
@@ -61,7 +61,12 @@ Requires:       python3-botocore
 %package -n     python3-%{name}-beaker
 Summary:        Beaker provider plugin for mrack
 Requires:       python3-%{name}lib = %{version}-%{release}
+%if 0%{?rhel} == 8
+# c8s has missing beaker-client package
+Recommends:     beaker-client
+%else
 Requires:       beaker-client
+%endif
 
 %{?python_provide:%python_provide python3-%{name}-beaker}
 

--- a/src/mrack/transformers/transformer.py
+++ b/src/mrack/transformers/transformer.py
@@ -16,8 +16,8 @@
 
 import logging
 import os
+import sys
 import typing
-from functools import cache
 
 from mrack.context import global_context
 from mrack.errors import ConfigError, MetadataError, ValidationError
@@ -28,6 +28,21 @@ from mrack.utils import (
     object2json,
     validate_dict_attrs,
 )
+
+if sys.version_info >= (3, 9):
+    from functools import cache
+else:
+    from functools import lru_cache
+
+    # Add cache decorator for the releases using python <= 3.9, e.g. c8s with py3.6
+    def cache(user_function):
+        """
+        Add simple lightweight unbounded cache.
+
+        Sometimes called "memoize".
+        """
+        return lru_cache(maxsize=None)(user_function)
+
 
 DEFAULT_ATTEMPTS = 1
 


### PR DESCRIPTION
    fix: Add cache decorator for older python versions.
    
    fix(mrack.spec): Missing dependency in c8s for beaker-client