### PR TITLE
chore(Packit): Add missing ci.fmf to synced files

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,6 +10,11 @@ files_to_sync:
   - .packit.yaml
   - gating.yaml
   - ci.fmf
+# we need to sync tmt for TF to work in Fedora updates
+  - src: ./tests/smoke/*
+    dest: ./tests/smoke/
+  - src: ./plans/*
+    dest: ./plans/
 
 # Allow dist git reactions on packit and tdudlak commits and PRs
 allowed_pr_authors:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,6 +9,7 @@ files_to_sync:
   - README.md
   - .packit.yaml
   - gating.yaml
+  - ci.fmf
 
 # name in upstream package repository/registry (e.g. in PyPI)
 upstream_package_name: mrack

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,6 +11,14 @@ files_to_sync:
   - gating.yaml
   - ci.fmf
 
+# Allow dist git reactions on packit and tdudlak commits and PRs
+allowed_pr_authors:
+  - packit
+  - tdudlak
+allowed_committers:
+  - packit
+  - tdudlak
+
 # name in upstream package repository/registry (e.g. in PyPI)
 upstream_package_name: mrack
 # downstream (Fedora) RPM package name


### PR DESCRIPTION
Missing ci.fmf sync causes fedora message being not recognized 
in dowsntream and thus expected tests to be marked as failed
even when tests might be run and passing. 

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>