### PR TITLE
feat: Do not use same sleep for every mrack run

### DIFF
--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -142,3 +142,11 @@ class MrackConfig:
     def require_owner(self, default=False):
         """Return value of require-owner."""
         return value_to_bool(self.get("require-owner", default))
+
+    def delta_sleep(self, default=15):
+        """Return value of require-owner."""
+        return int(self.get("delta-sleep", default))
+
+    def max_utilization(self, default=90):
+        """Return value of require-owner."""
+        return int(self.get("max-utilization", default))

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -300,7 +300,23 @@ class AWSProvider(Provider):
 
     async def utilization(self):
         """Check percentage utilization of given provider."""
-        return 0  # TODO
+        net_sizes = {
+            "28": 14,
+            "27": 30,
+            "26": 62,
+            "25": 126,
+            "24": 254,
+            "23": 510,
+        }
+        res = 0
+        for net, _availability in self.subnets_capacity.items():
+            subnet = self.ec2.Subnet(net)
+            size = net_sizes[subnet.cidr_block.split("/")[-1]]
+            self.subnets_capacity[net] = subnet.available_ip_address_count
+            usage = (size - self.subnets_capacity[net]) / size * 100
+            res = usage if usage > res else res
+
+        return res
 
     async def create_server(self, req):
         """Issue creation of a server.

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -40,6 +40,7 @@ class AWSProvider(Provider):
 
     def __init__(self):
         """Object initialization."""
+        super().__init__()
         self._name = PROVISIONER_KEY
         self.dsp_name = "AWS"
         self.ssh_key = None
@@ -296,6 +297,10 @@ class AWSProvider(Provider):
                 return False
 
         return True
+
+    async def utilization(self):
+        """Check percentage utilization of given provider."""
+        return 0  # TODO
 
     async def create_server(self, req):
         """Issue creation of a server.

--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -77,6 +77,7 @@ class BeakerProvider(Provider):
 
     def __init__(self):
         """Object initialization."""
+        super().__init__()
         self._name = PROVISIONER_KEY
         self.dsp_name = "Beaker"
         self.conf = PyConfigParser()
@@ -152,6 +153,10 @@ class BeakerProvider(Provider):
     async def can_provision(self, hosts):
         """Check that hosts can be provisioned."""
         return True
+
+    async def utilization(self):
+        """Check percentage utilization of given provider."""
+        return 0
 
     def _req_to_bkr_job(self, req):  # pylint: disable=too-many-locals
         """Transform requirement to beaker job xml."""

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -61,6 +61,7 @@ class OpenStackProvider(Provider):
 
     def __init__(self):
         """Object initialization."""
+        super().__init__()
         self._name = PROVISIONER_KEY
         self.dsp_name = "OpenStack"
         self.max_retry = 1  # provisioning retries
@@ -671,6 +672,10 @@ class OpenStackProvider(Provider):
         )
 
         return req_vcpus <= limit_vcpus and req_memory <= limit_memory
+
+    async def utilization(self):
+        """Check utilization of provider."""
+        return 0  # TODO
 
     async def create_server(self, req):
         """Issue creation of a server.

--- a/src/mrack/providers/podman.py
+++ b/src/mrack/providers/podman.py
@@ -35,6 +35,7 @@ class PodmanProvider(Provider):
 
     def __init__(self):
         """Initialize provider."""
+        super().__init__()
         self._name = PROVISIONER_KEY
         self.dsp_name = "Podman"
         self.max_retry = 1  # for retry strategy
@@ -126,6 +127,10 @@ class PodmanProvider(Provider):
     async def can_provision(self, hosts):
         """Check that provider has enough resources to provision hosts."""
         return bool(hosts)  # TODO
+
+    async def utilization(self):
+        """Check percentage utilization of given provider."""
+        return 0
 
     async def create_server(self, req):
         """Request and create resource on selected provider."""

--- a/src/mrack/providers/static.py
+++ b/src/mrack/providers/static.py
@@ -36,6 +36,7 @@ class StaticProvider(Provider):
 
     def __init__(self):
         """Object initialization."""
+        super().__init__()
         self._name = PROVISIONER_KEY
         self.dsp_name = "Static"
         self.max_retry = 1  # for retry strategy
@@ -63,6 +64,10 @@ class StaticProvider(Provider):
     async def can_provision(self, hosts):
         """Behave as that we can."""
         return True
+
+    async def utilization(self):
+        """Check percentage utilization of given provider."""
+        return 0
 
     async def provision_hosts(self, reqs):
         """Fake provision - behave as if it was provisioned."""

--- a/src/mrack/providers/virt.py
+++ b/src/mrack/providers/virt.py
@@ -39,6 +39,7 @@ class VirtProvider(Provider):
 
     def __init__(self):
         """Initialize provider."""
+        super().__init__()
         self._name = PROVISIONER_KEY
         self.dsp_name = "Virt"
         self.testcloud = Testcloud()
@@ -127,6 +128,10 @@ class VirtProvider(Provider):
         """Check that provider has enough resources to provision hosts."""
         # We'd need to check available memory, this is TODO
         return bool(hosts)
+
+    async def utilization(self):
+        """Check percentage utilization of given provider."""
+        return 0
 
     async def create_server(self, req):
         """Request and create resource on Virt provider."""


### PR DESCRIPTION
feat: Do not use same sleep for every mrack run
    
    Adding logic to randomize the timeout to basically
    set the waiting timeout to vary from 45-75 minutes randomly
    and the poll time to 45-75 seconds accordingly
    so if there are multiple parallel runs of mrack they wait
    different amount time before poll and increase chance to get resources
    quicker than other concurrent runs of mrack requests
    
    Add cooldown after error host was found to wait before
    another retry and resource check cycle for random time
    between one poll sleep and 2* poll sleep (45-75 s is one poll)
    
    Add utilization method template to decide whether to
    destroy all machines or to keep them while re-provisioning
    to free some resources when there is provided highly utilized.
    
feat(AWS): Add utilization check method
    
feat(OpenStack): Add utilization check method
    
    minor fix: typo _opentack -> _openstack

refactor(OpenStack): make private openstack methods truly private
    
    renaming the openstack private methods to be private
    openstack had too many public methods and this seems
    to be proper fix, to have public just the needed ones.
    
Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>
    