### PR TITLE
feat(OpenStack): Provide a way to disable network spreading

### DIFF
--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -144,9 +144,26 @@ class MrackConfig:
         return value_to_bool(self.get("require-owner", default))
 
     def delta_sleep(self, default=15):
-        """Return value of require-owner."""
+        """Return value of `delta-sleep` value from config to randomize sleep window."""
         return int(self.get("delta-sleep", default))
 
+    @property
     def max_utilization(self, default=90):
-        """Return value of require-owner."""
+        """Return value `max-utilization` from mrack config file."""
         return int(self.get("max-utilization", default))
+
+    @property
+    def usable_network_threshold(self, default=95):
+        """Return maximum acceptable network utilization of provider."""
+        return int(self.get("usable-network-threshold", default))
+
+    @property
+    def network_spread(self, default="allow"):
+        """Return `network-spread` setting value from mrack config.
+
+        Possible values are:
+        - no: disable network spreading feature
+        - allow: allow network spreading feature (default)
+        - force: always use network spreading feature
+        """
+        return self.get("network-spread", default).lower()

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -241,11 +241,11 @@ class OpenStackProvider(Provider):
         Full capacity of these 5 nets: 500
 
         Normalized network range:
-        net 4 - <0, 0.29>
-        net 3 - (0,29, 0.55>
-        net 5 - (0.55, 0.76>
-        net 2 - (0.76, 0.96>
-        net 1 - (0.96, 1>
+        net 4 - <0, 0.29)
+        net 3 - <0,29, 0.55)
+        net 5 - <0.55, 0.76)
+        net 2 - <0.76, 0.96)
+        net 1 - <0.96, 1)
 
         Which will divide networks for hosts:
         host 1 => net 4 (0 falls into net 4 interval)
@@ -258,7 +258,7 @@ class OpenStackProvider(Provider):
         """
         chosen = tuple()
         for index, net in enumerate(nets_weights):
-            if host_weight <= net[NETWORK_SIZE]:
+            if host_weight < net[NETWORK_SIZE]:
                 chosen = net
                 # print details only if there is more one network to be picked from
                 if len(nets_weights) > 1:

--- a/tests/unit/conf/mrack.conf
+++ b/tests/unit/conf/mrack.conf
@@ -1,0 +1,2 @@
+[mrack]
+mrackdb = ./mrackdb.json

--- a/tests/unit/conf/mrack_force_spread.conf
+++ b/tests/unit/conf/mrack_force_spread.conf
@@ -1,0 +1,3 @@
+[mrack]
+mrackdb = ./mrackdb.json
+network-spread = force

--- a/tests/unit/conf/mrack_no_spread.conf
+++ b/tests/unit/conf/mrack_no_spread.conf
@@ -1,0 +1,3 @@
+[mrack]
+mrackdb = ./mrackdb.json
+network-spread = no

--- a/tests/unit/conf/provisioning-config.yaml
+++ b/tests/unit/conf/provisioning-config.yaml
@@ -1,0 +1,72 @@
+---
+# for Mrack provisioner
+ssh_key_filename: 'config/id_rsa'
+
+# mrack provisioning supports also static provisioning
+# this record is needed (mrack v0.5.2) to enable it
+static: {}
+
+
+openstack:
+    images:
+        fedora-37: Fedora-Cloud-Base-37-latest
+
+
+    flavors:
+        default: medium
+
+
+    networks:
+        IPv4:
+            - net1
+
+    default_network: IPv4
+
+    # OpenStack vm config
+    keypair: default_keypair
+
+    # OpenStack security/auth config for linchpin
+    credentials_file: clouds.yaml
+    profile: devstack
+
+
+# default user of image
+users:
+    fedora-37: fedora
+    default: cloud-user
+
+# ansible_python_interpreter
+python:
+    fedora-37: /usr/bin/python3
+    default: /usr/libexec/platform-python
+
+mhcfg:
+    ssh_key_filename: 'config/id_rsa'
+    ad_admin_name: Administrator
+    ad_admin_password: Secret123
+    admin_name: admin
+    admin_password: Secret.123
+    dirman_dn: cn=Directory Manager
+    dirman_password: Secret.123
+    dns_forwarder: '10.11.5.19' # taken from OpenStack machine
+
+inventory_layout:
+    all:
+        children:
+            ad:
+                children:
+                    ad_root: {}
+                    ad_subdomain: {}
+                    ad_treedomain: {}
+                    ad_member: {}
+            ipa:
+                children:
+                    ipaclient: {}
+                    ipaserver: {}
+            linux:
+                children:
+                    ipa: {}
+                    runner: {}
+            windows:
+                children:
+                    ad: {}

--- a/tests/unit/mock_networks.py
+++ b/tests/unit/mock_networks.py
@@ -1,0 +1,134 @@
+import uuid
+
+
+def mock_subnet_ip_availability(name, version, total_ips, used_ips):
+    subnet = {
+        "cidr": "10.0.10.0/22",  # this won't probably match total_ips now
+        "ip_version": version,
+        "subnet_id": str(uuid.uuid4()),
+        "subnet_name": name,
+        "total_ips": total_ips,
+        "used_ips": used_ips,
+    }
+    if version == 6:
+        subnet["cidr"] = "2828:60:0:80::/64"
+    return subnet
+
+
+def mock_network_availability(name, total_ips, used_ips, version, project, tenant):
+    return {
+        "network_id": str(uuid.uuid4()),
+        "network_name": name,
+        "project_id": project,
+        "subnet_ip_availability": [
+            mock_subnet_ip_availability(f"subnet_{name}", version, total_ips, used_ips),
+        ],
+        "tenant_id": tenant,
+        "total_ips": total_ips,
+        "used_ips": used_ips,
+    }
+
+
+def mock_network_ip_availabilities(availabilities_data):
+    """
+    Create mock object simulating OpenStack network availability call.
+
+    Expected input format:
+      List of dict with keys
+        network: str,
+        total: int,
+        used: int,
+        version: int - 4 or 6,
+
+    E.g.
+      [{"name": "net1", "total": 255, "used": 25, "version": 4},]
+
+    Returns:
+    """
+    availabilities = []
+    project = str(uuid.uuid4())
+    tenant = str(uuid.uuid4())
+    for data in availabilities_data:
+        av = mock_network_availability(
+            data["network"],
+            data["total"],
+            data["used"],
+            data["version"],
+            project,
+            tenant,
+        )
+        availabilities.append(av)
+    return {
+        "network_ip_availabilities": availabilities,
+    }
+
+
+def mock_networks_from_availabilities(availabilities):
+    """
+    Mock networks call, create from availabilities data.
+    """
+    networks = []
+
+    for availability in availabilities["network_ip_availabilities"]:
+        subnets = [
+            subnet["subnet_id"] for subnet in availability["subnet_ip_availability"]
+        ]
+        network = {
+            "admin_state_up": True,
+            "availability_zone_hints": [],
+            "availability_zones": ["nova"],
+            "created_at": "2019-08-19T07:54:27Z",
+            "description": "",
+            "id": availability["network_id"],
+            "ipv4_address_scope": None,
+            "ipv6_address_scope": None,
+            "is_default": False,
+            "l2_adjacency": True,
+            "mtu": 1500,
+            "name": availability["network_name"],
+            "port_security_enabled": True,
+            "project_id": availability["project_id"],
+            "qos_policy_id": None,
+            "revision_number": 12,
+            "router:external": True,
+            "shared": True,
+            "status": "ACTIVE",
+            "subnets": subnets,
+            "tags": [],
+            "tenant_id": availability["tenant_id"],
+            "updated_at": "2019-08-27T12:43:31Z",
+        }
+        networks.append(network)
+    return {
+        "networks": networks,
+    }
+
+
+def mock_pools(availabilities):
+    ip4 = []
+    ip6 = []
+    dual = []
+
+    for availability in availabilities["network_ip_availabilities"]:
+        is_4 = False
+        is_6 = False
+
+        for subnet in availability["subnet_ip_availability"]:
+            if subnet["ip_version"] == 4:
+                is_4 = True
+            if subnet["ip_version"] == 6:
+                is_6 = True
+
+        name = availability["network_name"]
+        if is_4:
+            ip4.append(name)
+        if is_6:
+            ip6.append(name)
+        if is_4 and is_6:
+            dual.append(name)
+
+    return {
+        "IPv4": ip4,
+        "IPv6": ip6,
+        "dual": dual,
+    }

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -11,13 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
 
-from mrack.errors import MrackError, ValidationError
+from mrack.context import global_context
+from mrack.errors import MrackError, ProviderNotExists, ValidationError
 from mrack.providers.openstack import OpenStackProvider
 
 from .utils import get_data  # FIXME do not use relative import
@@ -75,8 +77,8 @@ net_3 = networks[2]
 net_3["used_ips"] = 989
 net_3["subnet_ip_availability"][0]["used_ips"] = 989
 
-no_usable_traceback_2ips_left = deepcopy(mocked_nets)
-networks = no_usable_traceback_2ips_left["network_ip_availabilities"]
+net_2ips_left = deepcopy(mocked_nets)
+networks = net_2ips_left["network_ip_availabilities"]
 net_1 = networks[0]
 net_1["used_ips"] = net_1["total_ips"] - 1
 net_1["subnet_ip_availability"][0]["used_ips"] = net_1["total_ips"] - 1
@@ -84,8 +86,8 @@ net_3 = networks[2]
 net_3["used_ips"] = net_3["total_ips"] - 1
 net_3["subnet_ip_availability"][0]["used_ips"] = net_3["total_ips"] - 1
 
-no_usable_traceback_no_ips_left = deepcopy(mocked_nets)
-networks = no_usable_traceback_no_ips_left["network_ip_availabilities"]
+no_available_nets_traceback = deepcopy(mocked_nets)
+networks = no_available_nets_traceback["network_ip_availabilities"]
 net_1 = networks[0]
 net_1["used_ips"] = net_1["total_ips"]
 net_1["subnet_ip_availability"][0]["used_ips"] = net_1["total_ips"]
@@ -97,21 +99,21 @@ net_3["subnet_ip_availability"][0]["used_ips"] = net_3["total_ips"]
 net_pools = get_data("network_pools.json")
 network_data = [
     (
-        "empty-hosts",  # test name
+        "tc-0-empty-hosts",  # test name
         [],  # hosts
         {},  # network pools
         {},  # networks
         [],  # result
     ),
     (
-        "test1-host_net3-usable",
+        "tc1-1-host_net3-usable",
         [deepcopy(predefined_hosts[0])],
         net_pools,
         net3_usable,
         [["net_3"]],
     ),
     (
-        "test2-hosts_net3-usable",
+        "tc2-2-hosts_net3-usable",
         [
             deepcopy(predefined_hosts[0]),
             deepcopy(predefined_hosts[1]),
@@ -121,7 +123,7 @@ network_data = [
         [["net_3"], ["net_3"]],
     ),
     (
-        "test3-hosts_net3-usable",
+        "tc-3-3-hosts_net3-usable",
         [
             deepcopy(predefined_hosts[0]),
             deepcopy(predefined_hosts[1]),
@@ -132,7 +134,7 @@ network_data = [
         [["net_3"], ["net_3"], ["net_3"]],
     ),
     (
-        "test3-hosts_low-availability_net1_prio",
+        "tc-4-3-hosts_low-availability_net1_prio",
         [
             deepcopy(predefined_hosts[0]),
             deepcopy(predefined_hosts[1]),
@@ -143,7 +145,7 @@ network_data = [
         [["net_1"], ["net_1"], ["net_3"]],
     ),
     (
-        "test3-hosts_low-availability_net3_prio",
+        "tc-5-3-hosts_low-availability_net3_prio",
         [
             deepcopy(predefined_hosts[0]),
             deepcopy(predefined_hosts[1]),
@@ -154,35 +156,101 @@ network_data = [
         [["net_3"], ["net_3"], ["net_1"]],
     ),
     (
-        "test3-hosts_no_usable_traceback_2ips_left",
+        "tc-6-3-hosts_no_usable_traceback_2ips_left",
         [
             deepcopy(predefined_hosts[0]),
             deepcopy(predefined_hosts[1]),
             deepcopy(predefined_hosts[2]),
         ],
         net_pools,
-        no_usable_traceback_2ips_left,
-        ValidationError("OpenStack Error: no available networks for 3 hosts with IPv4"),
+        net_2ips_left,
+        ValidationError("no available networks"),
     ),
     (
-        "test1-host_low-availability_1random_from_all_nets",
+        "tc-7-2-hosts_no_usable_2ips_left",
+        [
+            deepcopy(predefined_hosts[0]),
+            deepcopy(predefined_hosts[1]),
+        ],
+        net_pools,
+        net_2ips_left,
+        [["net_1", "net_3"], ["net_1", "net_3"]],
+    ),
+    (
+        "tc-8-1-host_low-availability",
         [deepcopy(predefined_hosts[0])],
         net_pools,
         low_availability_net3_prio,
         [["net_3", "net_1"]],
     ),
     (
-        "test3-hosts_no_usable_traceback_no_ips_left",
+        "tc-9-3-hosts_no_available_nets_traceback",
         [
             deepcopy(predefined_hosts[0]),
             deepcopy(predefined_hosts[1]),
             deepcopy(predefined_hosts[2]),
         ],
         net_pools,
-        no_usable_traceback_no_ips_left,
-        ValidationError("Error: no available networks for 3 hosts with IPv4"),
+        no_available_nets_traceback,
+        ValidationError("no available networks"),
+    ),
+    (
+        "tc-10-3-hosts_mocked_nets_should_not_spread",
+        [
+            deepcopy(predefined_hosts[0]),
+            deepcopy(predefined_hosts[1]),
+            deepcopy(predefined_hosts[2]),
+        ],
+        net_pools,
+        mocked_nets,
+        [["net_1", "net_3"], ["net_1", "net_3"], ["net_1", "net_3"]],
     ),
 ]
+
+# In case of network spread set to no alg behaves differently and needs
+# expected result update, which we expect as outcome from alg
+no_spread_results = [deepcopy(d[4]) for d in network_data]  # we copy results
+# index is tc number from network_data tc-NUMBER-TESTNAME
+# and we change the test case result for each test case number when needed
+no_spread_results[4] = ValidationError("Can not satisfy request")
+no_spread_results[5] = ValidationError("Can not satisfy request")
+no_spread_results[6] = ValidationError("no available networks")
+no_spread_results[7] = ValidationError("Can not satisfy request")
+no_spread_results[8] = ValidationError("Can not satisfy request")
+
+network_data_no = []
+# after that we just copy the values to new list of inputs for parametrized test
+for i, in_data in enumerate(deepcopy(network_data)):
+    network_data_no.append(
+        (
+            in_data[0],
+            in_data[1],
+            in_data[2],
+            in_data[3],
+            no_spread_results[i],
+        )
+    )
+
+# In case of network spread set to force alg behaves differently and needs
+# expected result update, which we expect as outcome from alg
+force_spread_results = [deepcopy(d[4]) for d in network_data]  # we copy results
+# index is tc number from network_data tc-NUMBER-TESTNAME
+# and we change the test case result for each test case number when needed
+force_spread_results[10] = [["net_3"], ["net_3"], ["net_1"]]
+
+
+network_data_force = []
+# after that we just copy the values to new list of inputs for parametrized test
+for i, in_data in enumerate(deepcopy(network_data)):
+    network_data_force.append(
+        (
+            in_data[0],
+            in_data[1],
+            in_data[2],
+            in_data[3],
+            force_spread_results[i],
+        )
+    )
 
 
 def AsyncMock(*args, **kwargs):
@@ -295,9 +363,16 @@ class TestOpenStackProvider:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("x", network_data, ids=[x[0] for x in network_data])
-    async def test_network_picking_validation(self, x):
-        _, hosts, pools, availability, exp_nets = x
+    async def test_network_picking_default_allow_spread(self, x):
+        (
+            _name,
+            hosts,
+            pools,
+            availability,
+            exp_nets,
+        ) = x
         reqs = deepcopy(hosts)
+        mrack_conf = "mrack.conf"
         if availability:
             del self.mock_neutron
             self.mock_neutron = Mock()
@@ -311,14 +386,33 @@ class TestOpenStackProvider:
             )
             self.neutron_patcher.start()
 
+        try:
+            global_context.init(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    f"conf/{mrack_conf}",
+                ),
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "conf/provisioning-config.yaml",
+                ),
+            )
+        except ProviderNotExists:
+            assert global_context.CONFIG is not None
+            assert isinstance(global_context.CONFIG.max_network_utilization(), int)
+            assert global_context.CONFIG.network_spread() == "allow"
+            assert global_context.CONFIG.max_network_utilization() == 75
+            # ignore that provider is not registered
+            # as global_context contains needed values
+
         provider = OpenStackProvider()
 
         await provider.init(image_names=[], networks=pools)
         try:
             provider._translate_network_types(hosts)  # pylint: disable=protected-access
         except MrackError as no_nets:
-            assert isinstance(exp_nets, ValidationError) is True
-            assert "no available networks" in str(no_nets)
+            assert isinstance(exp_nets, ValidationError)
+            assert exp_nets.args[0] in no_nets.args[0]
             assert str(len(hosts)) in str(no_nets)
             return True
 
@@ -327,3 +421,142 @@ class TestOpenStackProvider:
             assert host != reqs[i]
             assert host["network"] in pools.get(reqs[i]["network"])
             assert host["network"] in exp_nets[i]
+
+        if exp_nets and all([len(e) > 1 for e in exp_nets]):
+            unique_net_cnt = 2 if net_2ips_left == availability else 1
+            assert len(set([h["network"] for h in hosts])) == unique_net_cnt
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "x", network_data_force, ids=[x[0] for x in network_data_force]
+    )
+    async def test_network_picking_force_spread(self, x):
+        (
+            _test_name,
+            hosts,
+            pools,
+            availability,
+            exp_nets,
+        ) = x
+        reqs = deepcopy(hosts)
+        mrack_conf = "mrack_force_spread.conf"
+
+        if availability:
+            del self.mock_neutron
+            self.mock_neutron = Mock()
+            self.mock_neutron.init_api = AsyncMock(return_value=True)
+            self.mock_neutron.network.list = AsyncMock(return_value=self.networks)
+            self.mock_neutron.ip.list = AsyncMock(return_value=availability)
+
+            self.mock_neutron_class = Mock(return_value=self.mock_neutron)
+            self.neutron_patcher = patch(
+                "mrack.providers.openstack.NeutronClient", new=self.mock_neutron_class
+            )
+            self.neutron_patcher.start()
+
+        try:
+            global_context.init(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    f"conf/{mrack_conf}",
+                ),
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "conf/provisioning-config.yaml",
+                ),
+            )
+        except ProviderNotExists:
+            assert global_context.CONFIG is not None
+            assert isinstance(global_context.CONFIG.max_network_utilization(), int)
+            assert global_context.CONFIG.network_spread() == "force"
+            assert global_context.CONFIG.max_network_utilization() == 75
+            # ignore that provider is not registered
+            # as global_context contains needed values
+
+        provider = OpenStackProvider()
+
+        await provider.init(image_names=[], networks=pools)
+        try:
+            provider._translate_network_types(hosts)  # pylint: disable=protected-access
+        except MrackError as no_nets:
+            assert isinstance(exp_nets, ValidationError) is True
+            assert exp_nets.args[0] in no_nets.args[0]
+            assert str(len(hosts)) in str(no_nets)
+            return True
+
+        assert len(hosts) == len(reqs)
+        for i, host in enumerate(hosts):
+            assert host != reqs[i]
+            assert host["network"] in pools.get(reqs[i]["network"])
+            assert host["network"] in exp_nets[i]
+
+        if hosts:
+            unique_net_cnt = 0 if net3_usable == availability else 1
+            assert (
+                len(set([h["network"] for h in hosts])) >= unique_net_cnt
+            )  # only if spread is force
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("x", network_data_no, ids=[x[0] for x in network_data_no])
+    async def test_network_picking_no_spread(self, x):
+        (
+            _test_name,
+            hosts,
+            pools,
+            availability,
+            exp_nets,
+        ) = x
+        reqs = deepcopy(hosts)
+        mrack_conf = "mrack_no_spread.conf"
+
+        if availability:
+            del self.mock_neutron
+            self.mock_neutron = Mock()
+            self.mock_neutron.init_api = AsyncMock(return_value=True)
+            self.mock_neutron.network.list = AsyncMock(return_value=self.networks)
+            self.mock_neutron.ip.list = AsyncMock(return_value=availability)
+
+            self.mock_neutron_class = Mock(return_value=self.mock_neutron)
+            self.neutron_patcher = patch(
+                "mrack.providers.openstack.NeutronClient", new=self.mock_neutron_class
+            )
+            self.neutron_patcher.start()
+
+        try:
+            global_context.init(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    f"conf/{mrack_conf}",
+                ),
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "conf/provisioning-config.yaml",
+                ),
+            )
+        except ProviderNotExists:
+            assert global_context.CONFIG is not None
+            assert isinstance(global_context.CONFIG.max_network_utilization(), int)
+            assert global_context.CONFIG.network_spread() == "no"
+            assert global_context.CONFIG.max_network_utilization() == 75
+            # ignore that provider is not registered
+            # as global_context contains needed values
+
+        provider = OpenStackProvider()
+
+        await provider.init(image_names=[], networks=pools)
+        try:
+            provider._translate_network_types(hosts)  # pylint: disable=protected-access
+        except MrackError as no_nets:
+            assert isinstance(exp_nets, ValidationError)
+            assert str(exp_nets) in str(no_nets)
+            assert str(len(hosts)) in str(no_nets)
+            return True
+
+        assert len(hosts) == len(reqs)
+        for i, host in enumerate(hosts):
+            assert host != reqs[i]
+            assert host["network"] in pools.get(reqs[i]["network"])
+            assert host["network"] in exp_nets[i]
+
+        if hosts:
+            assert len(set([h["network"] for h in hosts])) == 1  # only if spread is no

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -22,11 +22,17 @@ from mrack.context import global_context
 from mrack.errors import MrackError, ProviderNotExists, ValidationError
 from mrack.providers.openstack import OpenStackProvider
 
+from .mock_networks import (
+    mock_network_ip_availabilities,
+    mock_networks_from_availabilities,
+    mock_pools,
+)
 from .utils import get_data  # FIXME do not use relative import
 
-predefined_hosts = [
-    {
-        "name": "f-latest-0.mrack.test",
+
+def hostX(x):
+    return {
+        "name": f"host{x}.mrack.test",
         "os": "fedora-latest",
         "group": "ipaclient",
         "flavor": "ci.standard.xs",
@@ -34,223 +40,76 @@ predefined_hosts = [
         "key_name": "idm-jenkins",
         "network": "IPv4",
         "config_drive": True,
-    },
-    {
-        "name": "f-latest-1.mrack.test",
-        "os": "fedora-latest",
-        "group": "ipaclient",
-        "flavor": "ci.standard.xs",
-        "image": "idm-Fedora-Cloud-Base-37-latest",
-        "key_name": "idm-jenkins",
-        "network": "IPv4",
-        "config_drive": True,
-    },
-    {
-        "name": "f-latest-2.mrack.test",
-        "os": "fedora-latest",
-        "group": "ipaclient",
-        "flavor": "ci.standard.xs",
-        "image": "idm-Fedora-Cloud-Base-37-latest",
-        "key_name": "idm-jenkins",
-        "network": "IPv4",
-        "config_drive": True,
-    },
-]
-
-mocked_nets = get_data("network_availabilities.json")
-
-net3_usable = deepcopy(mocked_nets)
-networks = net3_usable["network_ip_availabilities"]
-net_1 = networks[0]
-net_1["used_ips"] = 999
-net_1["subnet_ip_availability"][0]["used_ips"] = 999
-
-low_availability_net1_prio = deepcopy(net3_usable)
-networks = low_availability_net1_prio["network_ip_availabilities"]
-net_3 = networks[2]
-net_3["used_ips"] = 1000
-net_3["subnet_ip_availability"][0]["used_ips"] = 1000
-
-low_availability_net3_prio = deepcopy(net3_usable)
-networks = low_availability_net3_prio["network_ip_availabilities"]
-net_3 = networks[2]
-net_3["used_ips"] = 989
-net_3["subnet_ip_availability"][0]["used_ips"] = 989
-
-net_2ips_left = deepcopy(mocked_nets)
-networks = net_2ips_left["network_ip_availabilities"]
-net_1 = networks[0]
-net_1["used_ips"] = net_1["total_ips"] - 1
-net_1["subnet_ip_availability"][0]["used_ips"] = net_1["total_ips"] - 1
-net_3 = networks[2]
-net_3["used_ips"] = net_3["total_ips"] - 1
-net_3["subnet_ip_availability"][0]["used_ips"] = net_3["total_ips"] - 1
-
-no_available_nets_traceback = deepcopy(mocked_nets)
-networks = no_available_nets_traceback["network_ip_availabilities"]
-net_1 = networks[0]
-net_1["used_ips"] = net_1["total_ips"]
-net_1["subnet_ip_availability"][0]["used_ips"] = net_1["total_ips"]
-net_3 = networks[2]
-net_3["used_ips"] = net_3["total_ips"]
-net_3["subnet_ip_availability"][0]["used_ips"] = net_3["total_ips"]
+    }
 
 
-net_pools = get_data("network_pools.json")
-network_data = [
-    (
-        "tc-0-empty-hosts",  # test name
-        [],  # hosts
-        {},  # network pools
-        {},  # networks
-        [],  # result
-    ),
-    (
-        "tc1-1-host_net3-usable",
-        [deepcopy(predefined_hosts[0])],
-        net_pools,
-        net3_usable,
-        [["net_3"]],
-    ),
-    (
-        "tc2-2-hosts_net3-usable",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-        ],
-        net_pools,
-        net3_usable,
-        [["net_3"], ["net_3"]],
-    ),
-    (
-        "tc-3-3-hosts_net3-usable",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-            deepcopy(predefined_hosts[2]),
-        ],
-        net_pools,
-        net3_usable,
-        [["net_3"], ["net_3"], ["net_3"]],
-    ),
-    (
-        "tc-4-3-hosts_low-availability_net1_prio",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-            deepcopy(predefined_hosts[2]),
-        ],
-        net_pools,
-        low_availability_net1_prio,
-        [["net_1"], ["net_1"], ["net_3"]],
-    ),
-    (
-        "tc-5-3-hosts_low-availability_net3_prio",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-            deepcopy(predefined_hosts[2]),
-        ],
-        net_pools,
-        low_availability_net3_prio,
-        [["net_3"], ["net_3"], ["net_1"]],
-    ),
-    (
-        "tc-6-3-hosts_no_usable_traceback_2ips_left",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-            deepcopy(predefined_hosts[2]),
-        ],
-        net_pools,
-        net_2ips_left,
-        ValidationError("no available networks"),
-    ),
-    (
-        "tc-7-2-hosts_no_usable_2ips_left",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-        ],
-        net_pools,
-        net_2ips_left,
-        [["net_1", "net_3"], ["net_1", "net_3"]],
-    ),
-    (
-        "tc-8-1-host_low-availability",
-        [deepcopy(predefined_hosts[0])],
-        net_pools,
-        low_availability_net3_prio,
-        [["net_3", "net_1"]],
-    ),
-    (
-        "tc-9-3-hosts_no_available_nets_traceback",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-            deepcopy(predefined_hosts[2]),
-        ],
-        net_pools,
-        no_available_nets_traceback,
-        ValidationError("no available networks"),
-    ),
-    (
-        "tc-10-3-hosts_mocked_nets_should_not_spread",
-        [
-            deepcopy(predefined_hosts[0]),
-            deepcopy(predefined_hosts[1]),
-            deepcopy(predefined_hosts[2]),
-        ],
-        net_pools,
-        mocked_nets,
-        [["net_1", "net_3"], ["net_1", "net_3"], ["net_1", "net_3"]],
-    ),
-]
+def host1():
+    return hostX(1)
 
-# In case of network spread set to no alg behaves differently and needs
-# expected result update, which we expect as outcome from alg
-no_spread_results = [deepcopy(d[4]) for d in network_data]  # we copy results
-# index is tc number from network_data tc-NUMBER-TESTNAME
-# and we change the test case result for each test case number when needed
-no_spread_results[4] = ValidationError("Can not satisfy request")
-no_spread_results[5] = ValidationError("Can not satisfy request")
-no_spread_results[6] = ValidationError("no available networks")
-no_spread_results[7] = ValidationError("Can not satisfy request")
-no_spread_results[8] = ValidationError("Can not satisfy request")
 
-network_data_no = []
-# after that we just copy the values to new list of inputs for parametrized test
-for i, in_data in enumerate(deepcopy(network_data)):
-    network_data_no.append(
-        (
-            in_data[0],
-            in_data[1],
-            in_data[2],
-            in_data[3],
-            no_spread_results[i],
+def host2():
+    return hostX(2)
+
+
+def host3():
+    return hostX(3)
+
+
+def net_availability(network_name, total_ips, used_ips, ip_version):
+    return {
+        "network": network_name,
+        "total": total_ips,
+        "used": used_ips,
+        "version": ip_version,
+    }
+
+
+def init_global_context(mrack_conf="mrack.conf"):
+    try:
+        global_context.init(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                f"conf/{mrack_conf}",
+            ),
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "conf/provisioning-config.yaml",
+            ),
         )
-    )
-
-# In case of network spread set to force alg behaves differently and needs
-# expected result update, which we expect as outcome from alg
-force_spread_results = [deepcopy(d[4]) for d in network_data]  # we copy results
-# index is tc number from network_data tc-NUMBER-TESTNAME
-# and we change the test case result for each test case number when needed
-force_spread_results[10] = [["net_3"], ["net_3"], ["net_1"]]
+    except ProviderNotExists:
+        assert global_context.CONFIG is not None
 
 
-network_data_force = []
-# after that we just copy the values to new list of inputs for parametrized test
-for i, in_data in enumerate(deepcopy(network_data)):
-    network_data_force.append(
-        (
-            in_data[0],
-            in_data[1],
-            in_data[2],
-            in_data[3],
-            force_spread_results[i],
-        )
-    )
+def assert_global_network_config(spread, utilization):
+    """
+    Check that network allocation settings in global config are set as expected.
+    """
+    assert isinstance(global_context.CONFIG.usable_network_threshold, int)
+    assert global_context.CONFIG.network_spread == spread
+    assert global_context.CONFIG.usable_network_threshold == utilization
+
+
+def assert_network_alloc_exception(expected, raised, hosts):
+    """
+    Check that allocation of networks raises excepted exception
+    """
+    assert isinstance(expected, ValidationError), f"Unexpected exception: {raised}"
+    assert expected.args[0] in raised.args[0], "List"
+    assert str(len(hosts)) in str(raised)
+
+
+def assert_network_allocation(hosts, reqs, pools, expected):
+    assert len(hosts) == len(reqs)
+
+    allocation = [h["network"] for h in hosts]
+
+    for i, host in enumerate(hosts):
+        assert host != reqs[i]
+        picked = host["network"]
+        assert picked in pools.get(reqs[i]["network"])
+        assert (
+            picked == expected[i]
+        ), f"host: '{i}', expected: '{expected[i]}'. Allocation: {allocation}"
 
 
 def AsyncMock(*args, **kwargs):
@@ -264,7 +123,7 @@ def AsyncMock(*args, **kwargs):
 
 
 class TestOpenStackProvider:
-    def setup(self):
+    def setup_method(self):
         self.limits = get_data("limits.json")
         self.flavors = get_data("flavors.json")
         self.images = get_data("images.json")
@@ -307,8 +166,21 @@ class TestOpenStackProvider:
         )
         self.glance_patcher.start()
 
-    def teardown(self):
+    def teardown_method(self):
         mock.patch.stopall()
+
+    def mock_osp_network_calls(self, availabilities, networks):
+        del self.mock_neutron
+        self.mock_neutron = Mock()
+        self.mock_neutron.init_api = AsyncMock(return_value=True)
+        self.mock_neutron.network.list = AsyncMock(return_value=networks)
+        self.mock_neutron.ip.list = AsyncMock(return_value=availabilities)
+
+        self.mock_neutron_class = Mock(return_value=self.mock_neutron)
+        self.neutron_patcher = patch(
+            "mrack.providers.openstack.NeutronClient", new=self.mock_neutron_class
+        )
+        self.neutron_patcher.start()
 
     @pytest.mark.asyncio
     async def test_init_provider(self):
@@ -361,202 +233,273 @@ class TestOpenStackProvider:
         provider = OpenStackProvider()
         await provider.init(image_names=[])
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("x", network_data, ids=[x[0] for x in network_data])
-    async def test_network_picking_default_allow_spread(self, x):
-        (
-            _name,
-            hosts,
-            pools,
-            availability,
-            exp_nets,
-        ) = x
+    async def translate_network_types_test_core(
+        self, x, mrack_conf, spread, utilization
+    ):
+        hosts = x["hosts"]
         reqs = deepcopy(hosts)
-        mrack_conf = "mrack.conf"
-        if availability:
-            del self.mock_neutron
-            self.mock_neutron = Mock()
-            self.mock_neutron.init_api = AsyncMock(return_value=True)
-            self.mock_neutron.network.list = AsyncMock(return_value=self.networks)
-            self.mock_neutron.ip.list = AsyncMock(return_value=availability)
+        availabilities_data = x["availabilities_data"]
+        expected = x["expected"]
 
-            self.mock_neutron_class = Mock(return_value=self.mock_neutron)
-            self.neutron_patcher = patch(
-                "mrack.providers.openstack.NeutronClient", new=self.mock_neutron_class
-            )
-            self.neutron_patcher.start()
+        availabilities = mock_network_ip_availabilities(availabilities_data)
+        networks = mock_networks_from_availabilities(availabilities)
+        pools = mock_pools(availabilities)
+        self.mock_osp_network_calls(availabilities, networks)
 
-        try:
-            global_context.init(
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)),
-                    f"conf/{mrack_conf}",
-                ),
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)),
-                    "conf/provisioning-config.yaml",
-                ),
-            )
-        except ProviderNotExists:
-            assert global_context.CONFIG is not None
-            assert isinstance(global_context.CONFIG.max_network_utilization(), int)
-            assert global_context.CONFIG.network_spread() == "allow"
-            assert global_context.CONFIG.max_network_utilization() == 75
-            # ignore that provider is not registered
-            # as global_context contains needed values
-
+        init_global_context(mrack_conf)
+        assert_global_network_config(spread, utilization)
         provider = OpenStackProvider()
-
         await provider.init(image_names=[], networks=pools)
+
         try:
             provider._translate_network_types(hosts)  # pylint: disable=protected-access
-        except MrackError as no_nets:
-            assert isinstance(exp_nets, ValidationError)
-            assert exp_nets.args[0] in no_nets.args[0]
-            assert str(len(hosts)) in str(no_nets)
+        except MrackError as raised:
+            assert_network_alloc_exception(expected, raised, hosts)
             return True
 
-        assert len(hosts) == len(reqs)
-        for i, host in enumerate(hosts):
-            assert host != reqs[i]
-            assert host["network"] in pools.get(reqs[i]["network"])
-            assert host["network"] in exp_nets[i]
+        assert_network_allocation(hosts, reqs, pools, expected)
 
-        if exp_nets and all([len(e) > 1 for e in exp_nets]):
-            unique_net_cnt = 2 if net_2ips_left == availability else 1
-            assert len(set([h["network"] for h in hosts])) == unique_net_cnt
+    network_spread_data = [
+        {
+            "name": "prefer_single",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                # way below treshold, prefers single network
+                net_availability("net1", 100, 50, 4),
+                net_availability("net2", 100, 51, 4),
+                net_availability("net3", 100, 52, 4),
+            ],
+            "expected": ["net1", "net1", "net1"],
+        },
+        {
+            "name": "prefer_single_2",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                # way below treshold, prefers single network
+                net_availability("net1", 100, 51, 4),
+                net_availability("net2", 100, 50, 4),
+                net_availability("net3", 100, 52, 4),
+            ],
+            "expected": ["net2", "net2", "net2"],
+        },
+        {
+            "name": "equal_spread",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                # all over treshold, spreads the networks equally
+                net_availability("net1", 100, 90, 4),
+                net_availability("net2", 100, 90, 4),
+                net_availability("net3", 100, 90, 4),
+            ],
+            "expected": ["net1", "net2", "net2"],
+        },
+        {
+            "name": "picks_single_almost_full",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 90, 4),
+            ],
+            "expected": ["net1", "net1", "net1"],
+        },
+        {
+            "name": "spread_in_usable",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 80, 4),
+                net_availability("net2", 100, 90, 4),
+                net_availability("net3", 100, 99, 4),
+            ],
+            "expected": ["net1", "net1", "net1"],
+        },
+        {
+            "name": "no_aval",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 99, 4),
+                net_availability("net2", 100, 100, 4),
+                net_availability("net3", 100, 99, 4),
+            ],
+            "expected": ValidationError("no available networks"),
+        },
+        {
+            "name": "can_fit",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 99, 4),
+                net_availability("net2", 100, 100, 4),
+                net_availability("net3", 100, 98, 4),
+            ],
+            "expected": ["net1", "net3", "net3"],
+        },
+    ]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "x", network_data_force, ids=[x[0] for x in network_data_force]
+        "x", network_spread_data, ids=[x["name"] for x in network_spread_data]
     )
-    async def test_network_picking_force_spread(self, x):
-        (
-            _test_name,
-            hosts,
-            pools,
-            availability,
-            exp_nets,
-        ) = x
-        reqs = deepcopy(hosts)
-        mrack_conf = "mrack_force_spread.conf"
+    async def test_network_picking_default_allow_spread(self, x):
 
-        if availability:
-            del self.mock_neutron
-            self.mock_neutron = Mock()
-            self.mock_neutron.init_api = AsyncMock(return_value=True)
-            self.mock_neutron.network.list = AsyncMock(return_value=self.networks)
-            self.mock_neutron.ip.list = AsyncMock(return_value=availability)
+        await self.translate_network_types_test_core(x, "mrack.conf", "allow", 95)
 
-            self.mock_neutron_class = Mock(return_value=self.mock_neutron)
-            self.neutron_patcher = patch(
-                "mrack.providers.openstack.NeutronClient", new=self.mock_neutron_class
-            )
-            self.neutron_patcher.start()
-
-        try:
-            global_context.init(
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)),
-                    f"conf/{mrack_conf}",
-                ),
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)),
-                    "conf/provisioning-config.yaml",
-                ),
-            )
-        except ProviderNotExists:
-            assert global_context.CONFIG is not None
-            assert isinstance(global_context.CONFIG.max_network_utilization(), int)
-            assert global_context.CONFIG.network_spread() == "force"
-            assert global_context.CONFIG.max_network_utilization() == 75
-            # ignore that provider is not registered
-            # as global_context contains needed values
-
-        provider = OpenStackProvider()
-
-        await provider.init(image_names=[], networks=pools)
-        try:
-            provider._translate_network_types(hosts)  # pylint: disable=protected-access
-        except MrackError as no_nets:
-            assert isinstance(exp_nets, ValidationError) is True
-            assert exp_nets.args[0] in no_nets.args[0]
-            assert str(len(hosts)) in str(no_nets)
-            return True
-
-        assert len(hosts) == len(reqs)
-        for i, host in enumerate(hosts):
-            assert host != reqs[i]
-            assert host["network"] in pools.get(reqs[i]["network"])
-            assert host["network"] in exp_nets[i]
-
-        if hosts:
-            unique_net_cnt = 0 if net3_usable == availability else 1
-            assert (
-                len(set([h["network"] for h in hosts])) >= unique_net_cnt
-            )  # only if spread is force
+    network_force_spread_data = [
+        {
+            "name": "spread1",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 50, 4),
+                net_availability("net2", 100, 51, 4),
+                net_availability("net3", 100, 52, 4),
+            ],
+            "expected": ["net1", "net1", "net2"],
+        },
+        {
+            "name": "spread2",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 51, 4),
+                net_availability("net2", 100, 50, 4),
+                net_availability("net3", 100, 52, 4),
+            ],
+            "expected": ["net2", "net2", "net1"],
+        },
+        {
+            "name": "equal_spread",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 90, 4),
+                net_availability("net2", 100, 90, 4),
+                net_availability("net3", 100, 90, 4),
+            ],
+            "expected": ["net1", "net3", "net2"],
+        },
+        {
+            "name": "picks_single_almost_full",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 90, 4),
+            ],
+            "expected": ["net1", "net1", "net1"],
+        },
+        {
+            "name": "spread_in_usable",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 80, 4),
+                net_availability("net2", 100, 90, 4),
+                net_availability("net3", 100, 99, 4),
+            ],
+            "expected": ["net1", "net1", "net1"],
+        },
+        {
+            "name": "no_aval",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 99, 4),
+                net_availability("net2", 100, 100, 4),
+                net_availability("net3", 100, 99, 4),
+            ],
+            "expected": ValidationError("no available networks"),
+        },
+        {
+            "name": "can_fit",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 99, 4),
+                net_availability("net2", 100, 100, 4),
+                net_availability("net3", 100, 98, 4),
+            ],
+            "expected": ["net1", "net1", "net3"],
+        },
+    ]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("x", network_data_no, ids=[x[0] for x in network_data_no])
+    @pytest.mark.parametrize(
+        "x",
+        network_force_spread_data,
+        ids=[x["name"] for x in network_force_spread_data],
+    )
+    async def test_network_picking_force_spread(self, x):
+        await self.translate_network_types_test_core(
+            x, "mrack_force_spread.conf", "force", 95
+        )
+
+    network_data_no = [
+        {
+            "name": "picks_most_empty",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 51, 4),
+                net_availability("net2", 100, 51, 4),
+                net_availability("net3", 100, 50, 4),
+            ],
+            "expected": ["net3", "net3", "net3"],
+        },
+        {
+            "name": "picks_most_empty2",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 54, 4),
+                net_availability("net2", 100, 50, 4),
+                net_availability("net3", 100, 54, 4),
+            ],
+            "expected": ["net2", "net2", "net2"],
+        },
+        {
+            "name": "picks_first",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 90, 4),
+                net_availability("net2", 100, 90, 4),
+                net_availability("net3", 100, 90, 4),
+            ],
+            "expected": ["net1", "net1", "net1"],
+        },
+        {
+            "name": "picks_single_almost_full",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 90, 4),
+                net_availability("net2", 100, 100, 4),
+            ],
+            "expected": ["net1", "net1", "net1"],
+        },
+        {
+            "name": "no_aval",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 99, 4),
+                net_availability("net2", 100, 100, 4),
+                net_availability("net3", 100, 99, 4),
+            ],
+            "expected": ValidationError("no available networks"),
+        },
+        {
+            "name": "fails_even_if_spread_possible",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 98, 4),
+                net_availability("net2", 100, 98, 4),
+                net_availability("net3", 100, 98, 4),
+            ],
+            "expected": ValidationError("Can not satisfy request"),
+        },
+        {
+            "name": "fails_even_if_spread_possible2",
+            "hosts": [host1(), host2(), host3()],
+            "availabilities_data": [
+                net_availability("net1", 100, 99, 4),
+                net_availability("net2", 100, 100, 4),
+                net_availability("net3", 100, 98, 4),
+            ],
+            "expected": ValidationError("Can not satisfy request"),
+        },
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "x", network_data_no, ids=[x["name"] for x in network_data_no]
+    )
     async def test_network_picking_no_spread(self, x):
-        (
-            _test_name,
-            hosts,
-            pools,
-            availability,
-            exp_nets,
-        ) = x
-        reqs = deepcopy(hosts)
-        mrack_conf = "mrack_no_spread.conf"
-
-        if availability:
-            del self.mock_neutron
-            self.mock_neutron = Mock()
-            self.mock_neutron.init_api = AsyncMock(return_value=True)
-            self.mock_neutron.network.list = AsyncMock(return_value=self.networks)
-            self.mock_neutron.ip.list = AsyncMock(return_value=availability)
-
-            self.mock_neutron_class = Mock(return_value=self.mock_neutron)
-            self.neutron_patcher = patch(
-                "mrack.providers.openstack.NeutronClient", new=self.mock_neutron_class
-            )
-            self.neutron_patcher.start()
-
-        try:
-            global_context.init(
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)),
-                    f"conf/{mrack_conf}",
-                ),
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)),
-                    "conf/provisioning-config.yaml",
-                ),
-            )
-        except ProviderNotExists:
-            assert global_context.CONFIG is not None
-            assert isinstance(global_context.CONFIG.max_network_utilization(), int)
-            assert global_context.CONFIG.network_spread() == "no"
-            assert global_context.CONFIG.max_network_utilization() == 75
-            # ignore that provider is not registered
-            # as global_context contains needed values
-
-        provider = OpenStackProvider()
-
-        await provider.init(image_names=[], networks=pools)
-        try:
-            provider._translate_network_types(hosts)  # pylint: disable=protected-access
-        except MrackError as no_nets:
-            assert isinstance(exp_nets, ValidationError)
-            assert str(exp_nets) in str(no_nets)
-            assert str(len(hosts)) in str(no_nets)
-            return True
-
-        assert len(hosts) == len(reqs)
-        for i, host in enumerate(hosts):
-            assert host != reqs[i]
-            assert host["network"] in pools.get(reqs[i]["network"])
-            assert host["network"] in exp_nets[i]
-
-        if hosts:
-            assert len(set([h["network"] for h in hosts])) == 1  # only if spread is no
+        await self.translate_network_types_test_core(
+            x, "mrack_no_spread.conf", "no", 95
+        )


### PR DESCRIPTION
The network spreading feature has aimed to utilize networks usage however for some particular products it might be not optimal to have resources on different networks. This patch is adding options to mrack.conf which can disable the feature and also set the acceptable threshold of network utilization for OpenStack.

network-spread = no/allow/force

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>