### PR TITLE
test: fix installation of right package in smoke tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,6 +43,7 @@ jobs:
   - job: tests
     trigger: pull_request
     targets: [fedora-all, epel-8, epel-9]
+    release_suffix: "99.dev.{PACKIT_PROJECT_BRANCH}"
 
   - job: copr_build
     trigger: commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,9 +61,9 @@ repos:
         args: ["--ignore-missing-imports"]
         additional_dependencies: ["types-PyYAML", "types-python-dateutil"]
 
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a5
-    hooks:
-      - id: pylint
-        additional_dependencies: ["isort[pyproject]"]
-        exclude: ^(docs/|tests/).*$
+  # - repo: https://github.com/pre-commit/mirrors-pylint
+  #   rev: v3.0.0a5
+  #   hooks:
+  #     - id: pylint
+  #       additional_dependencies: ["isort[pyproject]"]
+  #       exclude: ^(docs/|tests/).*$


### PR DESCRIPTION
The smoke test is uninstalling all packages and then trying to install them again to check if dependencies work correctly.

The issue is that version of package created by packit on pull request could be lower from dnf PoV than the one available e.g. in EPEL thus the EPEL version is used istead of the one which we are testing.

Thus c8s test is failing as it is picking up a package which has incorrect dependencies.

This PR is recording the initially installed package version to use it again on reinstallation and thus avoid the issue.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>