### PR TITLE
feat: Allow domain and global section records for ansible inventory 

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -190,9 +190,10 @@ class AnsibleInventoryOutput:
             if key.startswith("meta_"):
                 host_info[key] = val
 
-        ansible_inventory = meta_host.get("ansible_inventory")
-        if isinstance(ansible_inventory, dict):
-            host_info.update(ansible_inventory)
+        dom_ansible_inventory = deepcopy(meta_domain.get("ansible_inventory", {}))
+        ansible_inventory = deepcopy(meta_host.get("ansible_inventory", {}))
+        if ansible_inventory or dom_ansible_inventory:
+            host_info.update(dom_ansible_inventory | ansible_inventory)
 
         return host_info
 

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -190,10 +190,12 @@ class AnsibleInventoryOutput:
             if key.startswith("meta_"):
                 host_info[key] = val
 
-        dom_ansible_inventory = deepcopy(meta_domain.get("ansible_inventory", {}))
-        ansible_inventory = deepcopy(meta_host.get("ansible_inventory", {}))
-        if ansible_inventory or dom_ansible_inventory:
-            host_info.update(dom_ansible_inventory | ansible_inventory)
+        glob_ansible_inv = deepcopy(self._metadata.get("ansible_inventory", {}))
+        dom_ansible_inv = deepcopy(meta_domain.get("ansible_inventory", {}))
+        host_ansible_inv = deepcopy(meta_host.get("ansible_inventory", {}))
+
+        if any([glob_ansible_inv, dom_ansible_inv, host_ansible_inv]):
+            host_info.update(glob_ansible_inv | dom_ansible_inv | host_ansible_inv)
 
         return host_info
 

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -125,13 +125,13 @@ class PytestMultihostOutput:
                     mhcfg["ad_sub_hostname"] = host["name"]
                     mhcfg["ad_sub_ip"] = host["ip"]
 
-                host_custom_attrs = host.get("pytest_multihost")
+                host_custom_attrs = deepcopy(host.get("pytest_multihost", {}))
 
                 rm_keys = [key for key in host.keys() if key not in host_allowed_attrs]
                 for key in rm_keys:
                     del host[key]
 
-                if isinstance(host_custom_attrs, dict):
+                if host_custom_attrs:
                     host.update(host_custom_attrs)
 
             domain_rm_keys = [

--- a/tests/unit/test_ansible_inventory.py
+++ b/tests/unit/test_ansible_inventory.py
@@ -227,3 +227,77 @@ class TestAnsibleInventory:
         assert "something_else" in srv2
         assert srv2["no_ca"] == "yes"
         assert srv2["something_else"] == "for_fun"
+
+    def test_domain_arbitrary_attrs(self):
+        """
+        Test that values defined in `ansible_inventory` dictionary in host part
+        of job metadata file gets into host attributes in generated ansible
+        inventory.
+        """
+        metadata = metadata_extra()
+        metadata["domains"][0]["ansible_inventory"] = {
+            "no_ca": "no",
+            "something_else": "not_funny",
+        }
+
+        config = provisioning_config()
+        db = get_db_from_metadata(metadata)
+        ans_inv = AnsibleInventoryOutput(config, db, metadata)
+        inventory = ans_inv.create_inventory()
+
+        srv1 = inventory["all"]["hosts"]["srv1.example.test"]
+
+        assert "readonly_dc" not in srv1
+        assert "something_else" in srv1
+        assert srv1["something_else"] == "not_funny"
+        assert "no_ca" in srv1
+        assert "something_else" in srv1
+        assert srv1["no_ca"] == "no"
+        assert srv1["something_else"] == "not_funny"
+
+        srv2 = inventory["all"]["hosts"]["srv2.example.test"]
+        assert "no_ca" in srv2
+        assert "something_else" in srv2
+        assert srv2["no_ca"] == "no"
+        assert srv2["something_else"] == "not_funny"
+
+    def test_domain_arbitrary_attrs_override(self):
+        """
+        Test that values defined in `ansible_inventory` dictionary in host part
+        of job metadata file gets into host attributes in generated ansible
+        inventory.
+        """
+        metadata = metadata_extra()
+        metadata["domains"][0]["ansible_inventory"] = {
+            "no_ca": "no",
+            "something_else": "not_funny",
+        }
+        m_srv1 = metadata["domains"][0]["hosts"][0]
+        m_srv2 = metadata["domains"][0]["hosts"][1]
+        m_srv1["ansible_inventory"] = {
+            "readonly_dc": "yes",
+        }
+        m_srv2["ansible_inventory"] = {
+            "no_ca": "yes",
+            "something_else": "for_fun",
+        }
+
+        config = provisioning_config()
+        db = get_db_from_metadata(metadata)
+        ans_inv = AnsibleInventoryOutput(config, db, metadata)
+        inventory = ans_inv.create_inventory()
+
+        srv1 = inventory["all"]["hosts"]["srv1.example.test"]
+
+        assert "readonly_dc" in srv1
+        assert srv1["readonly_dc"] == "yes"
+        assert "something_else" in srv1
+        assert srv1["something_else"] == "not_funny"
+        assert "no_ca" in srv1
+        assert srv1["no_ca"] == "no"
+
+        srv2 = inventory["all"]["hosts"]["srv2.example.test"]
+        assert "no_ca" in srv2
+        assert "something_else" in srv2
+        assert srv2["no_ca"] == "yes"
+        assert srv2["something_else"] == "for_fun"


### PR DESCRIPTION

    
    feat(AnsibleInventory): Allow additional domain level ansible inventory values
    
    Add support for domain level ansible_inventory records which
    can be eventually overwritten by host defined values.
    Added unit tests to test this feature.   


    feat(AnsibleInventory): Allow additional global level values
    
    Add support for global level ansible_inventory records
    which can be eventually overwritten by domain and host defined values.
    Minor fix of logig in pytest multihost code - adding deepcopy.
    
    test(AnsibleInventory): global level output values override
    
    Add test for the feature to support global level
    ansible_inventory records which can be eventually
    overwritten by domain and host defined values.


    
    Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>
