### PR TITLE
chore: Bump python-semantic-release to latest

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           persist-credentials: false  # do not set the actions user to git config
           fetch-depth: 0
-      - name: Get the new version using python-semantic-releaseq
+      - name: Get the new version using python-semantic-release
         run: |
-          pip3 install python-semantic-release==7.32.2
+          pip3 install python-semantic-release==7.33.1
           echo "NEW_VERSION="`semantic-release print-version --noop` >> ${GITHUB_ENV}
       - name: Update the mrack.spec changelog with initiator and basic message
         run: |
@@ -69,7 +69,7 @@ jobs:
       - name: Add specfile to commit
         run: git add mrack.spec
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.32.2
+        uses: relekang/python-semantic-release@v7.33.1
         with:
           github_token: ${{ secrets.TIBORIS_GH_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Python-semantic-release had problems fetching
the commit's sha from work directory. This
issue should be fixed in latest release of action.