### PR TITLE
chore: update the changelog properly and sync files for packit

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -62,9 +62,18 @@ jobs:
           echo "NEW_VERSION="`semantic-release print-version --noop` >> ${GITHUB_ENV}
       - name: Update the mrack.spec changelog with initiator and basic message
         run: |
-          CHANGELOG_BODY="- Released upstream version $NEW_VERSION"
+          # get the history of commits and generate changelog from it
+          git log  --pretty=format:"- %h %s (%cn)" $(git describe --tags --abbrev=0)..HEAD > changelog_changes
+          # add newline after generated changelog for changelog sections to be visually separated
+          echo -e "\n" >> changelog_changes
+          echo "============NEW CHANGELOG================="
+          cat changelog_changes
+          echo "=========================================="
+          # write changelog to mrack.spec
+          sed -i '/%changelog/r changelog_changes' mrack.spec
+          # write header of changelog to mrack.spec
           sed -ri \
-          "s/\%changelog/\%changelog\\n\*\ $TODAY\ $RELEASE_ACTOR\ -\ $NEW_VERSION-1\\n$CHANGELOG_BODY\\n/" \
+          "s/\%changelog/\%changelog\\n\*\ $TODAY\ $RELEASE_ACTOR\ -\ $NEW_VERSION-1/" \
           mrack.spec
       - name: Add specfile to commit
         run: git add mrack.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,6 +32,8 @@ downstream_package_name: mrack
 # see: https://packit.dev/docs/configuration/#upstream_tag_template
 upstream_tag_template: "v{version}"
 
+sync_changelog: true
+
 actions:
   create-archive:
     - "python3 setup.py sdist --dist-dir ."

--- a/mrack.spec
+++ b/mrack.spec
@@ -1,6 +1,6 @@
 Name:           mrack
 Version:        1.12.3
-Release:        1%{?dist}
+Release:        4%{?dist}
 Summary:        Multicloud use-case based multihost async provisioner
 
 License:        Apache-2.0
@@ -182,11 +182,35 @@ rm -r src/%{name}.egg-info
 %{python3_sitelib}/%{name}/providers/utils/{,__pycache__/}testcloud.*
 
 %changelog
-* Tue Dec 13 2022 Tibor Dudlák <tdudlak@redhat.com> - 1.12.3-1
-- Released upstream version 1.12.3
+* Tue Dec 13 2022 Tibor Dudlák <tdudlak@redhat.com> - 1.12.3-4
+- chore: Add add tmt tests and plans and add them to sync (Tibor Dudlák)
 
-* Fri Dec 02 2022 Tibor Dudlák <tdudlak@redhat.com> - 1.12.2-1
-- Released upstream version 1.12.2
+* Tue Dec 13 2022 Tibor Dudlák <tdudlak@redhat.com> - 1.12.3-3
+- chore: Add fmf/version and allowed users to run packit (Tibor Dudlák)
+
+* Tue Dec 13 2022 Tibor Dudlák <tdudlak@redhat.com> - 1.12.3-2
+- chore: Add ci.fmf to the repo (Tibor Dudlák)
+
+* Tue Dec 13 2022 Packit <hello@packit.dev> - 1.12.3-1
+- chore: Release version 1.12.3 (github-actions)
+- chore(Packit): Enable copr build for commit to main only. (Tibor Dudlák)
+- chore(Packit): Enable TF tests job to run on pull request. (Tibor Dudlák)
+- chore(Packit): Add fedora gating.yaml to synced files. (Tibor Dudlák)
+- chore(TestingFarm): Add gating for fedora workflow (Tibor Dudlák)
+- fix: Add cache decorator for older python versions. (Tibor Dudlák)
+- fix(mrack.spec): Missing dependency in c8s for beaker-client (Tibor Dudlák)
+- chore(Packit): enable epel-8 and epel-9 updates and tests (Tibor Dudlák)
+- fix(AWS): refactor sources to be py3.6 compatible (Tibor Dudlák)
+
+* Fri Dec 02 2022 Packit <hello@packit.dev> - 1.12.2-1
+- chore: Release version 1.12.2 (github-actions)
+- chore: Use python 3.10 in GH actions (Tibor Dudlák)
+- refactor: pylint fixes related to Python 3.10 (Tibor Dudlák)
+- test: Fix test_utils.py to be included in pytest run (Tibor Dudlák)
+- chore(pytest): add missing python_path when using pytest >=7.0.0 (Tibor Dudlák)
+- test: Add test for value_to_bool util function (Tibor Dudlák)
+- fix: Owner requirement boolean parsing from string (Tibor Dudlák)
+- chore(Packit): Add upstream_tag_template to .packit.yaml (Tibor Dudlák)
 
 * Thu Nov 24 2022 Tibor Dudlák <tdudlak@redhat.com> - 1.12.1-1
 - Released upstream version 1.12.1

--- a/tests/smoke/smoke-test.sh
+++ b/tests/smoke/smoke-test.sh
@@ -4,9 +4,11 @@
 
 . /usr/share/beakerlib/beakerlib.sh || ( echo "FAILED to source beakerlib" && exit 1 )
 
+export DNF_EXTRA_OPTIONS=$([[ `rpm --eval '%{?dist}' | grep .el8` > /dev/null ]] && echo "--nobest")
+
 install_package () {
     rlPhaseStartSetup "Installing $1"
-        rlRun "dnf install -y $1"
+        rlRun "dnf install -y $1 $DNF_EXTRA_OPTIONS"
     rlPhaseEnd
 }
 


### PR DESCRIPTION
    chore: set packit to sync changelog as well
    
    chore: sync fedora spec to upstream to maintain changelog history for fedora
    
    chore: Generate proper changelog from commit history when releasing
    
    When releasing the package mrack.spec was not enriched
    by the history of changes compared to previous release
    this is enhancing the workflow to have proper changelog