### PR TITLE
feat: Add pytest-mh output and "config" section to metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = "Petr Vobornik"
 release = "1.13.3"
 
 # to work with ReadTheDocs which is using version < 2.0
-master_doc = 'index'
+master_doc = "index"
 
 # -- General configuration ---------------------------------------------------
 

--- a/src/mrack/actions/output.py
+++ b/src/mrack/actions/output.py
@@ -20,6 +20,7 @@ from mrack.context import global_context
 from mrack.errors import MetadataError
 from mrack.outputs.ansible_inventory import AnsibleInventoryOutput
 from mrack.outputs.pytest_multihost import PytestMultihostOutput
+from mrack.outputs.pytest_mh import PytestMhOutput
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ class Output(Action):
         db_driver=None,
         ansible_path=None,
         pytest_multihost_path=None,
+        pytest_mh_path=None,
     ):  # pylint: disable=arguments-differ
         """Initialize the Output action."""
         super().__init__(config=config, metadata=metadata, db_driver=db_driver)
@@ -45,12 +47,15 @@ class Output(Action):
         if global_context.CONFIG:
             global_ansible_path = global_context.CONFIG.ansible_inventory_path()
             global_multihost_path = global_context.CONFIG.pytest_multihost_path()
+            global_mh_path = global_context.CONFIG.pytest_mh_path()
         else:
             global_ansible_path = None
             global_multihost_path = None
+            global_mh_path = None
 
         self._ansible_path = ansible_path or global_ansible_path
         self._pytest_multihost_path = pytest_multihost_path or global_multihost_path
+        self._pytest_mh_path = pytest_mh_path or global_mh_path
 
     async def generate_outputs(self):
         """Generate outputs."""
@@ -65,9 +70,13 @@ class Output(Action):
         multihost_o = PytestMultihostOutput(
             self._config, self._db_driver, self._metadata, self._pytest_multihost_path
         )
+        mh_o = PytestMhOutput(
+            self._config, self._db_driver, self._metadata, self._pytest_multihost_path
+        )
 
         ansible_o.create_output()
         multihost_o.create_output()
+        mh_o.create_output()
 
         logger.info("Output generation done")
         return True

--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -139,6 +139,10 @@ class MrackConfig:
         """Return configured path to pytest-multihost configuration output."""
         return self.get("pytest-multihost", default)
 
+    def pytest_mh_path(self, default=None):
+        """Return configured path to pytest-mh configuration output."""
+        return self.get("pytest-mh", default)
+
     def require_owner(self, default=False):
         """Return value of require-owner."""
         return value_to_bool(self.get("require-owner", default))

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -23,6 +23,7 @@ from mrack.outputs.utils import get_external_id
 from mrack.utils import (
     get_fqdn,
     get_host_from_metadata,
+    get_os_type,
     get_password,
     get_shortname,
     get_ssh_key,
@@ -144,6 +145,7 @@ class AnsibleInventoryOutput:
             "ansible_host": ansible_host,
             "ansible_python_interpreter": python,
             "ansible_user": ansible_user,
+            "meta_os_type": get_os_type(meta_host),
             "meta_fqdn": f"{get_fqdn(name, dom_name)}",
             "meta_hostname": get_shortname(name),
             "meta_domain": f"{get_fqdn(name, dom_name).split('.', 1)[1]}",

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -74,7 +74,7 @@ def get_group(inventory, groupname):
         else:
             if "children" in group:
                 found = get_group(group["children"], groupname)
-        if found:
+        if found is not None:
             break
     return found
 
@@ -86,7 +86,7 @@ def add_to_group(inventory, groupname, hostname):
     Returns group or None if it doesn't exist.
     """
     group = get_group(inventory, groupname)
-    if not group:
+    if group is None:
         return None
 
     if "hosts" not in group:

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -202,12 +202,18 @@ class AnsibleInventoryOutput:
 
         return host_info
 
+    def get_inventory_layout(self):
+        """Get Ansible inventory layout."""
+        layout = self._metadata.get("config", {}).get("ansible", {}).get("layout")
+        if layout is None:
+            return self._config.get("inventory_layout", DEFAULT_INVENTORY_LAYOUT)
+
+        return layout
+
     def create_inventory(self):
         """Create the Ansible inventory in dict form."""
         provisioned = self._db.hosts
-        inventory = deepcopy(
-            self._config.get("inventory_layout", DEFAULT_INVENTORY_LAYOUT)
-        )
+        inventory = deepcopy(self.get_inventory_layout())
         if not isinstance(inventory, dict):
             raise ConfigError("Inventory layout should be a dictionary")
         all_group = ensure_all_group(inventory)

--- a/src/mrack/outputs/pytest_mh.py
+++ b/src/mrack/outputs/pytest_mh.py
@@ -1,0 +1,88 @@
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""pytest-mh configuration file output module."""
+
+import logging
+
+from mrack.outputs.utils import get_external_id
+from mrack.utils import get_fqdn, get_os_type, save_yaml
+
+DEFAULT_MHCFG_PATH = "pytest-mh.yaml"
+
+logger = logging.getLogger(__name__)
+
+
+class PytestMhOutput:
+    """
+    Create a configuration file for pytest-mh.
+
+    From job metadata and provisioned information (DB).
+
+    Structure of mh config file is almost the same as our topology in job
+    metadata definition.
+    """
+
+    def __init__(self, config, db, metadata, path=None):
+        """Init the output module."""
+        self._config = config
+        self._db = db
+        self._metadata = metadata
+        self._path = path or DEFAULT_MHCFG_PATH
+
+    def create_mh_config(self):
+        """
+        Create configuration file for python-pytest-multihost.
+
+        Return in form of dict.
+        """
+        cfg = {"domains": []}
+        for domain in self._metadata.get("domains", []):
+            cfgdom = {"id": domain["name"], "hosts": []}
+            cfg["domains"].append(cfgdom)
+
+            for host in domain.get("hosts", []):
+                if "role" not in host:
+                    continue
+
+                provisioned_host = self._db.hosts.get(host["name"], None)
+                if not provisioned_host:
+                    logger.error(f"Host {host['name']} not found in the database.")
+                    continue
+
+                cfgdom["hosts"].append(
+                    {
+                        "hostname": get_fqdn(host["name"], domain.get("name", "")),
+                        "os": {
+                            "family": get_os_type(host),
+                        },
+                        "role": host["role"],
+                        "ssh": {
+                            "host": get_external_id(
+                                provisioned_host, host, self._config
+                            ),
+                        },
+                        **host.get("pytest_mh", {}),
+                    }
+                )
+
+        return cfg
+
+    def create_output(self):
+        """Create the target output file."""
+        mhcfg = self.create_mh_config()
+        save_yaml(self._path, mhcfg, sort_keys=False)
+        if self._path:
+            logger.info(f"Created: {self._path}")
+        return mhcfg

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -54,6 +54,9 @@ class PytestMultihostOutput:
         if "phases" in mhcfg:
             del mhcfg["phases"]
 
+        if "config" in mhcfg:
+            del mhcfg["config"]
+
         # topology config in metadata contains more values (os, group) than the ones
         # needed by pytest multihost. They need to be removed in order to work.
         host_allowed_attrs = [

--- a/src/mrack/run.py
+++ b/src/mrack/run.py
@@ -112,6 +112,7 @@ async def generate_outputs(ctx):
         ctx.obj.DB,
         config.ansible_inventory_path(),
         config.pytest_multihost_path(),
+        config.pytest_mh_path(),
     )
     await output_action.generate_outputs()
 

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -277,6 +277,15 @@ def is_windows_host(meta_host):
     )
 
 
+def get_os_type(meta_host):
+    """Get os type from ``os_type`` or infer it from ``os``."""
+    os_type = meta_host.get("os_type")
+    if not os_type:
+        os_type = "linux" if not is_windows_host(meta_host) else "windows"
+
+    return os_type
+
+
 def get_shortname(hostname):
     """
     Get shortname part of fqdn.

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -227,14 +227,14 @@ def fd_open(filename=None):
             file_d.close()
 
 
-def save_yaml(path, yaml_data):
+def save_yaml(path, yaml_data, **kwargs):
     """
     Write yaml data with file.write(yaml.dump()) to file specified by path.
 
     If path is not specified use stdout.
     """
     with fd_open(path) as yaml_file:
-        yaml_file.write(yaml.dump(yaml_data, default_flow_style=False))
+        yaml_file.write(yaml.dump(yaml_data, default_flow_style=False, **kwargs))
 
 
 def object2json(obj):

--- a/src/mrack/utils.py
+++ b/src/mrack/utils.py
@@ -29,7 +29,7 @@ from xml.dom.minidom import Document as xml_doc
 
 import yaml
 
-from mrack.errors import ConfigError, MetadataError, ProvisioningError
+from mrack.errors import ConfigError, ProvisioningError
 
 logger = logging.getLogger(__name__)
 
@@ -300,13 +300,10 @@ def get_fqdn(hostname, domain):
     Get fqdn from hostname and domain.
 
     Return the hostname if it is fqdn otherwise append domain.
-    @raise: MetadataError when hostname is fqdn that does not belong to domain
     """
     if "." in hostname:
-        if hostname.endswith(domain):
-            return hostname
-        else:
-            raise MetadataError(f"{hostname} does not belong to {domain}.")
+        return hostname
+
     return f"{hostname}.{domain}"
 
 

--- a/tests/integration/data/metadata-hosts.yaml
+++ b/tests/integration/data/metadata-hosts.yaml
@@ -17,3 +17,4 @@ domains:
         role: master
         ip: 192.168.100.4
     name: aiohabit.test
+    type: test

--- a/tests/unit/test_ansible_inventory.py
+++ b/tests/unit/test_ansible_inventory.py
@@ -176,6 +176,28 @@ class TestAnsibleInventory:
             in inventory["all"]["children"]["server"]["children"]["ipaserver"]["hosts"]
         )
 
+    def test_layout_overwrite(self, db, metadata):
+        metadata["config"] = {
+            "ansible": {
+                "layout": {
+                    "all": {
+                        "children": {
+                            "mylayout": {},
+                        }
+                    }
+                }
+            }
+        }
+
+        config = provisioning_config(common_inventory_layout())
+        ans_inv = AnsibleInventoryOutput(config, db, metadata)
+        inventory = ans_inv.create_inventory()
+
+        assert "ipa" not in inventory["all"]["children"]
+        assert "linux" not in inventory["all"]["children"]
+        assert "windows" not in inventory["all"]["children"]
+        assert "mylayout" in inventory["all"]["children"]
+
     def test_meta_extra(self, db_meta_extra, metadata):
         config = provisioning_config()
         ans_inv = AnsibleInventoryOutput(config, db_meta_extra, metadata)

--- a/tests/unit/test_ansible_inventory.py
+++ b/tests/unit/test_ansible_inventory.py
@@ -101,7 +101,6 @@ class TestAnsibleInventory:
         ],
     )
     def test_layouts(self, layout, db, metadata):
-
         config = provisioning_config(layout)
         ans_inv = AnsibleInventoryOutput(config, db, metadata)
         inventory = ans_inv.create_inventory()
@@ -125,7 +124,6 @@ class TestAnsibleInventory:
         ],
     )
     def test_invalid_layouts(self, layout, db, metadata):
-
         config = provisioning_config(layout)
         ans_inv = AnsibleInventoryOutput(config, db, metadata)
 
@@ -134,7 +132,6 @@ class TestAnsibleInventory:
         assert "dictionary" in str(excinfo.value)
 
     def test_meta_extra(self, db_meta_extra, metadata):
-
         config = provisioning_config()
         ans_inv = AnsibleInventoryOutput(config, db_meta_extra, metadata)
         inventory = ans_inv.create_inventory()

--- a/tests/unit/test_pytest_mh.py
+++ b/tests/unit/test_pytest_mh.py
@@ -1,0 +1,88 @@
+import pytest
+import yaml
+
+from mrack.outputs.pytest_mh import PytestMhOutput
+
+from .mock_data import get_db_from_metadata, provisioning_config
+
+
+@pytest.fixture
+def mock_metadata():
+    return yaml.safe_load(
+        """
+    domains:
+    - name: test
+      hosts:
+      - name: dns.test
+        group: medium
+        os: fedora-37
+      - name: client.test
+        group: medium
+        groups:
+        - base_ground
+        - base_client
+        - client
+        role: client
+        os: fedora-37
+        pytest_mh:
+          artifacts:
+          - /etc/sssd/*
+          - /var/log/sssd/*
+          - /var/lib/sss/db/*
+      - name: master.ipa.test
+        group: ipa
+        groups:
+        - base_ground
+        - base_ldap
+        - base_ipa
+        - ipa
+        role: ipa
+        os: fedora-37
+        pytest_mh:
+          config:
+            client:
+              ipa_domain: ipa.test
+              krb5_keytab: /enrollment/ipa.keytab
+              ldap_krb5_keytab: /enrollment/ipa.keytab
+    """
+    )
+
+
+class TestPytestMhOutput:
+    def test_output(self, mock_metadata):
+        config = provisioning_config()
+        db = get_db_from_metadata(mock_metadata)
+
+        mhcfg_output = PytestMhOutput(config, db, mock_metadata)
+        mhcfg = mhcfg_output.create_mh_config()
+
+        expected = yaml.safe_load(
+            """
+        domains:
+        - id: test
+          hosts:
+          - hostname: client.test
+            os:
+              family: linux
+            role: client
+            ssh:
+              host: 192.168.0.1
+            artifacts:
+            - /etc/sssd/*
+            - /var/log/sssd/*
+            - /var/lib/sss/db/*
+          - hostname: master.ipa.test
+            os:
+              family: linux
+            role: ipa
+            ssh:
+              host: 192.168.0.1
+            config:
+              client:
+                ipa_domain: ipa.test
+                krb5_keytab: /enrollment/ipa.keytab
+                ldap_krb5_keytab: /enrollment/ipa.keytab
+        """
+        )
+
+        assert mhcfg == expected

--- a/tests/unit/test_pytest_multihost.py
+++ b/tests/unit/test_pytest_multihost.py
@@ -39,3 +39,27 @@ class TestPytestMultihostOutput:
         assert "something_else" in srv2
         assert srv2["no_ca"] == "yes"
         assert srv2["something_else"] == "for_fun"
+
+    def test_config_section_deleted(self):
+        """
+        Test that config section from metadata is not included in mhc.yaml.
+        """
+        metadata = metadata_extra()
+        metadata["config"] = {
+            "outputs": ["ansible-inventory", "pytest-multihost"],
+            "ansible": {
+                "layout": {
+                    "all": {
+                        "children": {
+                            "mylayout": {},
+                        }
+                    }
+                }
+            },
+        }
+        config = provisioning_config()
+        db = get_db_from_metadata(metadata)
+        mhcfg_output = PytestMultihostOutput(config, db, metadata)
+        mhcfg = mhcfg_output.create_multihost_config()
+
+        assert "config" not in mhcfg

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,13 @@
 import pytest
 
 from mrack.errors import MetadataError
-from mrack.utils import get_fqdn, get_shortname, get_username, value_to_bool
+from mrack.utils import (
+    get_fqdn,
+    get_os_type,
+    get_shortname,
+    get_username,
+    value_to_bool,
+)
 
 
 class TestPytestMrackUtils:
@@ -86,3 +92,17 @@ class TestPytestMrackUtils:
             assert value_to_bool(value) == expected
         except Exception as exc:
             assert isinstance(exc, expected)
+
+    @pytest.mark.parametrize(
+        "metahost,expected",
+        [
+            ({"os": "rhel-8.5"}, "linux"),
+            ({"os": "fedora-35"}, "linux"),
+            ({"os": "windows-2022"}, "windows"),
+            ({"os": "rhel-8.5", "os_type": "my-linux"}, "my-linux"),
+            ({"os": "fedora-35", "os_type": "my-linux"}, "my-linux"),
+            ({"os": "windows-2022", "os_type": "my-windows"}, "my-windows"),
+        ],
+    )
+    def test_get_os_type(self, metahost, expected):
+        assert get_os_type(metahost) == expected

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,5 @@
 import pytest
 
-from mrack.errors import MetadataError
 from mrack.utils import (
     get_fqdn,
     get_os_type,
@@ -35,8 +34,7 @@ class TestPytestMrackUtils:
         assert get_fqdn(hostname, domain) == expected
 
     def test_get_fqdn_mismatch(self):
-        with pytest.raises(MetadataError):
-            get_fqdn("foo.test", "domain.com")
+        assert get_fqdn("foo.test", "domain.com") == "foo.test"
 
     def test_get_username(
         self,


### PR DESCRIPTION
This adds new output for pytest-mh configuration file. Pytest-mh is
a complete rewrite of pytest-multihost with additional features that
is going to be used by SSSD. See: https://pytest-mh.readthedocs.io

This PR also adds `config` section to metadata file that currently can
contain:

* `outputs`: list of output files, defaults to `"anisble-inventory", "pytest-multihost`
* `ansible/layout`: to overwrite inventory_layout from provisioning-config