### PR TITLE
fix(OpenStack/Beaker): validation fails with exception when image/distro not found

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -47,7 +47,7 @@ PROVISIONER_KEY = "beaker"
 
 
 def parse_bkr_exc_str(exc_str):
-    """Parse exception string and return more readable string for mrack error."""
+    """Parse exception string and return response dictionary for mrack error."""
     # we expect exception string to look like following:
     # '<class \'bkr.common.bexceptions.BX\'>:No distro tree matches Recipe:
     # <distroRequires>
@@ -60,7 +60,7 @@ def parse_bkr_exc_str(exc_str):
         and "bkr.common.bexceptions" not in exc_str.faultString
     ):
         # we got string we do not expect so just use the traceback
-        return str(exc_str)
+        return {"response": str(exc_str)}
 
     # because of expected format we split by ":" and use last 2 values from list
     # in above example it would be
@@ -69,7 +69,7 @@ def parse_bkr_exc_str(exc_str):
     #   '\t<distroRequires><and><distro_name op="like" value="Fedora-33%"/> ...
     # ]
     fault = [f"\t{f.strip()}" for f in exc_str.faultString.split(":")[-2:]]
-    return "\n".join(fault)
+    return {"response": "\n".join(fault)}
 
 
 class BeakerProvider(Provider):

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -580,7 +580,7 @@ class OpenStackProvider(Provider):
 
         if not flavor:
             specs = f"flavor: {flavor_spec}, ref: {flavor_ref}"
-            raise ValidationError(f"Flavor not found: {specs}")
+            raise ValidationError(f"Flavor not found: {specs}", self.dsp_name)
         return flavor
 
     def _translate_image(self, req):
@@ -593,7 +593,7 @@ class OpenStackProvider(Provider):
             image = self._get_image(image_spec, image_spec)
         if not image:
             specs = f"image: {image_spec}, ref: {image_ref}"
-            raise ValidationError(f"Image not found {specs}")
+            raise ValidationError(f"Image not found {specs}", self.dsp_name)
         return image
 
     def _translate_networks(self, req, spec=False):
@@ -607,12 +607,16 @@ class OpenStackProvider(Provider):
             uuid = network_spec.get("uuid")
             network = self._get_network(ref=uuid)
             if not network:
-                raise ValidationError(f"Network not found: {network_spec}")
+                raise ValidationError(
+                    f"Network not found: {network_spec}", self.dsp_name
+                )
             networks.append(network)
         if network_req:
             network = self._get_network(name=network_req, ref=network_req)
             if not network:
-                raise ValidationError(f"Network not found: {network_req}")
+                raise ValidationError(
+                    f"Network not found: {network_req}", self.dsp_name
+                )
 
             network_specs.append({"uuid": network["id"]})
             networks.append(network)
@@ -690,7 +694,7 @@ class OpenStackProvider(Provider):
         except TypeError as flavor_none:
             # func does not load flavor so None is used as result
             raise ValidationError(
-                f"Could not load the flavor for requirement: {req}"
+                f"Could not load the flavor for requirement: {req}", self.dsp_name
             ) from flavor_none
 
         return res

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -462,7 +462,11 @@ class Provider:
                 out_of_resources = False
                 for host in error_hosts:
                     logger.error(f"{log_msg_start} Error: {str(host.error)}")
-                    if host.error.get("code", None) == 500:  # 500 = SERVER ERROR
+                    # if host.error is a dictionary and code is 500 = SERVER ERROR
+                    if (
+                        isinstance(host.error, dict)
+                        and host.error.get("code", None) == 500
+                    ):
                         logger.info(
                             f"{log_msg_start} Provider is out of resources, "
                             "increasing cooldown time before another retry"


### PR DESCRIPTION
fix(OpenStack): Add exception parameter when validation fails
    
    Adding second parameter to ValidationError exception gets rid of mrack exiting with exception.

fix(Beaker): rerurn common dictionary when validation fails

    when Beaker distro/image is not recognized by beakerhub
    mrack failed with exception as newer code expects
    dictionary error object.

fix: Use get method when host error object is a dictionary

    This makes sure to not throw an exception when host.error
    is not a dictionary and we can not use .get() method

