### PR TITLE
chore: change back mrack dist release to 1

### DIFF
--- a/mrack.spec
+++ b/mrack.spec
@@ -1,6 +1,6 @@
 Name:           mrack
 Version:        1.13.1
-Release:        4%{?dist}
+Release:        1%{?dist}
 Summary:        Multicloud use-case based multihost async provisioner
 
 License:        Apache-2.0


### PR DESCRIPTION
this is a leftover from fedora packaging