### PR TITLE
[draft][rfc] mrack session + host as context holder

### DIFF
--- a/src/mrack/domain.py
+++ b/src/mrack/domain.py
@@ -1,0 +1,105 @@
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain object."""
+
+from typing import Dict, Set
+
+from errors import MrackError
+
+from mrack.host import Host
+from mrack.session import MrackSession
+
+
+class Domain:
+    """Domain.
+
+    Domain as defined in job metadata file
+    """
+
+    _session: MrackSession
+    _name: str
+    _type: str
+    _network: str
+    _hosts: Set[str]
+
+    def __init__(
+        self,
+        session,
+        name,
+        type,
+        network,
+        hosts: Set[str],
+    ):
+        """Initialize domain object."""
+        self._session = session
+        self._name = name
+        self._type = type
+        self._network = network
+        self._hosts = hosts
+
+    def __str__(self):
+        """Return string representation of domain."""
+        host_count = len(self._hosts)
+        out = f"{self._name} {self._type} {self._network}, hosts: {host_count}"
+
+        return out
+
+    def to_json(self) -> Dict:
+        """Transform object into representation which is acceptable by `json.dump`."""
+        return {
+            "name": self._name,
+            "type": self._type,
+            "network": self._network,
+            "hosts": self._hosts,
+        }
+
+    @property
+    def name(self) -> str:
+        """Get host provisioning provider."""
+        return self._name
+
+    @property
+    def type(self) -> str:
+        """Get host operating system."""
+        return self._type
+
+    @property
+    def network(self) -> str:
+        """Get host group."""
+        return self._network
+
+    @property
+    def hosts(self) -> Set[Host]:
+        """Get provider host id."""
+        hosts: Set[Host] = set()
+        for host in self._hosts:
+            try:
+                hosts.add(self._session.hosts[host])
+            except ValueError:
+                raise MrackError(f"Session is missing host: {host}")
+
+        return hosts
+
+
+def domain_from_json(session: MrackSession, data: Dict) -> Domain:
+    """Reverse method to Host.__json__() after json.loads()."""
+    domain = Domain(
+        session,
+        data["name"],
+        data["type"],
+        data["network"],
+        data["hosts"],
+    )
+    return domain

--- a/src/mrack/session.py
+++ b/src/mrack/session.py
@@ -93,7 +93,7 @@ class MrackSession:
 
     def _init_db(self, path: str):
         """Initialize file database."""
-        self._database = FileDBDriver(path)
+        self._database = FileDBDriver(self, path)
 
     @NoSuchFileHandler(error="Provisioning config file not found: {path}")
     def _init_prov_config(self, path: str):

--- a/src/mrack/session.py
+++ b/src/mrack/session.py
@@ -1,0 +1,117 @@
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mrack session."""
+
+import os
+from typing import Dict, Optional
+
+from mrack.config import MrackConfig, ProvisioningConfig
+from mrack.dbdrivers.file import FileDBDriver
+from mrack.domain import Domain
+from mrack.errors import ConfigError
+from mrack.host import Host
+from mrack.utils import NoSuchFileHandler, load_yaml
+
+
+class MrackSession:
+    """A provisioning re-usable session."""
+
+    _database: FileDBDriver
+    _mrack_config: MrackConfig
+    _provisioning_config: ProvisioningConfig
+    _metadata: Dict
+    _hosts: Dict[str, Host]
+    _domains: Dict[str, Domain]
+
+    def __init__(self) -> None:
+        """Init session."""
+        self._metadata = {}
+        self._hosts = {}
+        self._domains = {}
+
+    @property
+    def database(self) -> FileDBDriver:  # pylint: disable=invalid-name
+        """Get FileDBDriver object."""
+        return self._database
+
+    @property
+    def config(self) -> MrackConfig:  # pylint: disable=invalid-name
+        """Get MrackConfig object."""
+        return self._mrack_config
+
+    @property
+    def provisioning_config(self) -> ProvisioningConfig:  # pylint: disable=invalid-name
+        """Get ProvisioningConfig object."""
+        return self._provisioning_config
+
+    @property
+    def metadata(self) -> Dict:  # pylint: disable=invalid-name
+        """Get ProvisioningConfig object."""
+        return self._metadata
+
+    @property
+    def hosts(self) -> Dict[str, Host]:  # pylint: disable=invalid-name
+        """Get dictionary of hosts where key is host name."""
+        return self._hosts
+
+    @property
+    def domains(self) -> Dict[str, Domain]:  # pylint: disable=invalid-name
+        """Get dictionary of domains where key is domain name."""
+        return self._domains
+
+    def init(
+        self,
+        mrack_config_path: str,
+        provisioning_config: Optional[ProvisioningConfig] = None,
+        db_file: Optional[str] = None,
+    ):
+        """Initialize MrackSession object with all needed values."""
+        self._init_mrack_config(mrack_config_path)
+
+        db_path = db_file or self._mrack_config.db_path(default="./.mrackdb.json")
+        p_config_path = (
+            provisioning_config
+            or self._mrack_config.provisioning_config_path(
+                default="./provisioning-config.yaml"
+            )
+        )
+
+        self._init_db(db_path)
+        self._init_prov_config(p_config_path)
+
+    def _init_db(self, path: str):
+        """Initialize file database."""
+        self._database = FileDBDriver(path)
+
+    @NoSuchFileHandler(error="Provisioning config file not found: {path}")
+    def _init_prov_config(self, path: str):
+        """Load and initialize provisioning configuration."""
+        self._provisioning_config = ProvisioningConfig(load_yaml(path))
+
+    def init_metadata(self, user_defined_path: Optional[str]):
+        """Load and initialize job metadata."""
+        meta_path = user_defined_path or self._mrack_config.metadata_path()
+
+        if not meta_path:
+            raise ConfigError("Job metadata file path not provided.")
+        if not os.path.exists(meta_path):
+            raise ConfigError(f"Job metadata file not found: {meta_path}")
+
+        self._metadata = load_yaml(meta_path)
+
+    def _init_mrack_config(self, mrack_config_path: str):
+        """Load and initialize mrack configuration."""
+        self._mrack_config = MrackConfig(mrack_config_path)
+        self._mrack_config.load()

--- a/src/mrack/session.py
+++ b/src/mrack/session.py
@@ -22,6 +22,8 @@ from mrack.dbdrivers.file import FileDBDriver
 from mrack.domain import Domain
 from mrack.errors import ConfigError
 from mrack.host import Host
+from mrack.providers import Registry as ProviderRegistry
+from mrack.transformers import Registry as TransformerRegistry
 from mrack.utils import NoSuchFileHandler, load_yaml
 
 
@@ -34,12 +36,16 @@ class MrackSession:
     _metadata: Dict
     _hosts: Dict[str, Host]
     _domains: Dict[str, Domain]
+    _providers: ProviderRegistry
+    _transformers: TransformerRegistry
 
     def __init__(self) -> None:
         """Init session."""
         self._metadata = {}
         self._hosts = {}
         self._domains = {}
+        self._providers = ProviderRegistry()
+        self._transformers = TransformerRegistry()
 
     @property
     def database(self) -> FileDBDriver:  # pylint: disable=invalid-name
@@ -70,6 +76,16 @@ class MrackSession:
     def domains(self) -> Dict[str, Domain]:  # pylint: disable=invalid-name
         """Get dictionary of domains where key is domain name."""
         return self._domains
+
+    @property
+    def providers(self) -> ProviderRegistry:
+        """Get ProviderRegistry."""
+        return self._providers
+
+    @property
+    def transformers(self) -> TransformerRegistry:
+        """Get ProviderRegistry."""
+        return self._transformers
 
     def init(
         self,

--- a/src/mrack/transformers/__init__.py
+++ b/src/mrack/transformers/__init__.py
@@ -26,57 +26,63 @@ from mrack.transformers.transformer import Transformer
 
 NAME = 0
 CLASS = 1
-installed_transformers: Set[Tuple[str, Type[Transformer]]] = set()
-IMPORT_ERR_TEMPLATE = "Transformer '%s' not installed, skipping registration"
+
 logger = logging.getLogger(__name__)
 
-try:
-    from mrack.transformers.aws import CONFIG_KEY as AWS_KEY
-    from mrack.transformers.aws import AWSTransformer
 
-    installed_transformers.add((AWS_KEY, AWSTransformer))
-except ModuleNotFoundError as import_err:
-    logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+def discover_transformers() -> Set[Tuple[str, Type[Transformer]]]:
+    """Discover installed transformers."""
+    installed_transformers: Set[Tuple[str, Type[Transformer]]] = set()
+    IMPORT_ERR_TEMPLATE = "Transformer '%s' not installed, skipping registration"
 
-try:
-    from mrack.transformers.beaker import CONFIG_KEY as BEAKER_KEY
-    from mrack.transformers.beaker import BeakerTransformer
+    try:
+        from mrack.transformers.aws import CONFIG_KEY as AWS_KEY
+        from mrack.transformers.aws import AWSTransformer
 
-    installed_transformers.add((BEAKER_KEY, BeakerTransformer))
-except ModuleNotFoundError as import_err:
-    logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+        installed_transformers.add((AWS_KEY, AWSTransformer))
+    except ModuleNotFoundError as import_err:
+        logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
 
-try:
-    from mrack.transformers.openstack import CONFIG_KEY as OPENSTACK_KEY
-    from mrack.transformers.openstack import OpenStackTransformer
+    try:
+        from mrack.transformers.beaker import CONFIG_KEY as BEAKER_KEY
+        from mrack.transformers.beaker import BeakerTransformer
 
-    installed_transformers.add((OPENSTACK_KEY, OpenStackTransformer))
-except ModuleNotFoundError as import_err:
-    logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+        installed_transformers.add((BEAKER_KEY, BeakerTransformer))
+    except ModuleNotFoundError as import_err:
+        logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
 
-try:
-    from mrack.transformers.podman import CONFIG_KEY as PODMAN_KEY
-    from mrack.transformers.podman import PodmanTransformer
+    try:
+        from mrack.transformers.openstack import CONFIG_KEY as OPENSTACK_KEY
+        from mrack.transformers.openstack import OpenStackTransformer
 
-    installed_transformers.add((PODMAN_KEY, PodmanTransformer))
-except ModuleNotFoundError as import_err:
-    logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+        installed_transformers.add((OPENSTACK_KEY, OpenStackTransformer))
+    except ModuleNotFoundError as import_err:
+        logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
 
-try:
-    from mrack.transformers.static import CONFIG_KEY as STATIC_KEY
-    from mrack.transformers.static import StaticTransformer
+    try:
+        from mrack.transformers.podman import CONFIG_KEY as PODMAN_KEY
+        from mrack.transformers.podman import PodmanTransformer
 
-    installed_transformers.add((STATIC_KEY, StaticTransformer))
-except ModuleNotFoundError as import_err:
-    logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+        installed_transformers.add((PODMAN_KEY, PodmanTransformer))
+    except ModuleNotFoundError as import_err:
+        logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
 
-try:
-    from mrack.transformers.virt import CONFIG_KEY as VIRT_KEY
-    from mrack.transformers.virt import VirtTransformer
+    try:
+        from mrack.transformers.static import CONFIG_KEY as STATIC_KEY
+        from mrack.transformers.static import StaticTransformer
 
-    installed_transformers.add((VIRT_KEY, VirtTransformer))
-except ModuleNotFoundError as import_err:
-    logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+        installed_transformers.add((STATIC_KEY, StaticTransformer))
+    except ModuleNotFoundError as import_err:
+        logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+
+    try:
+        from mrack.transformers.virt import CONFIG_KEY as VIRT_KEY
+        from mrack.transformers.virt import VirtTransformer
+
+        installed_transformers.add((VIRT_KEY, VirtTransformer))
+    except ModuleNotFoundError as import_err:
+        logger.debug(IMPORT_ERR_TEMPLATE, import_err.name)
+    return installed_transformers
 
 
 class Registry:
@@ -110,11 +116,14 @@ class Registry:
         """Get all registered transformer names."""
         return self._transformer_cls.keys()
 
+    def discover(self):
+        """Discover and add installed transformers."""
+        installed_transformers = discover_transformers()
+        for installed_transformer in installed_transformers:
+            self.register(
+                installed_transformer[NAME],
+                installed_transformer[CLASS],
+            )
+
 
 transformers = Registry()
-
-for installed_transformer in installed_transformers:
-    transformers.register(
-        installed_transformer[NAME],
-        installed_transformer[CLASS],
-    )


### PR DESCRIPTION
This PR is currently more like an idea/RFC (request-for-comments). There is a lot of stuff missing, opening early to get feedback if it is a good idea.

The idea behind this is to not use global objects and rather pass a session object which would contain whole context (config, provisioning config, metadata, database, initialized providers). Adding the session to other objects (host, providers, transformers, outputs, actions). 

I'd also unitize `Host` object for carrying a provisioning context. I.e. it would be initialized e.g. in following way:
- loaded from DB if was created by previous run
- updated from metadata (here we might intentionally fail, if metadata changed in incompatible way)
- updated by transformer (req added)
- update by provider (output of provisioning, deletion or out method)
- saved to DB

Also the PR adds more python typing - helps with the refactoring to find areas which has type mismatch.

The envisioned benefits/purposes are:

- easier unit testing (but this actually depends how other things are written)
- a possibility of having 2+ provisioning session running in single process in parallel with different inputs - this makes it more friendly for usage as a library.
- the usage of Host as context can make easier the future use case to add/remove host interactively (in different runs)