### PR TITLE
fix: Handle 403 AuthError (out of quota) in openstack provisioning

### DIFF
--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -22,7 +22,7 @@ from random import random, sample
 from urllib.parse import parse_qs, urlparse
 
 from asyncopenstackclient import AuthPassword, GlanceClient
-from simple_rest_client.exceptions import NotFoundError, ServerError
+from simple_rest_client.exceptions import AuthError, NotFoundError, ServerError
 
 from mrack.context import global_context
 from mrack.errors import (
@@ -816,6 +816,11 @@ class OpenStackProvider(Provider):
                 if error_attempts <= SERVER_ERROR_RETRY:
                     await asyncio.sleep(SERVER_ERROR_SLEEP)
                     continue  # Try again due to ServerError
+            except AuthError as exc:
+                raise ProvisioningError(
+                    f"{log_msg_start} Failed to create server: {exc}",
+                    req,
+                )
 
             fault = response["server"].get("fault", {})
 

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -97,9 +97,9 @@ class OpenStackProvider(Provider):
         * list of asyncio.gather results
         """
         error_attempts = 0
-        coros = [func(*args, **xargs) for (func, args, xargs) in calls]
         result = []
         while error_attempts < SERVER_ERROR_RETRY:
+            coros = [func(*args, **xargs) for (func, args, xargs) in calls]
             try:
                 result = await asyncio.gather(*coros)
                 break
@@ -108,8 +108,6 @@ class OpenStackProvider(Provider):
                 error_attempts += 1
                 if error_attempts <= SERVER_ERROR_RETRY:
                     await asyncio.sleep(SERVER_ERROR_SLEEP)
-                    # create new coroutines on ServerError
-                    coros = [func(*args, **xargs) for (func, args, xargs) in calls]
                     continue  # Try again due to ServerError
         else:
             # now we are past to what we would like to wait fail now

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
 import os
 from copy import deepcopy
 from unittest import mock
@@ -603,16 +602,15 @@ class TestOpenStackProvider:
         )
 
     @pytest.mark.asyncio
-    async def test_openstack_gather_responses(self):
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_openstack_gather_responses(self, mocked_sleep):
         error_flag = True
 
         async def coro1():
-            await asyncio.sleep(0.1)
             return "result1"
 
         async def coro2():
             nonlocal error_flag
-            await asyncio.sleep(0.2)
             if error_flag:
                 error_flag = False
                 raise ServerError("Oops!", 503)
@@ -620,7 +618,6 @@ class TestOpenStackProvider:
                 return "result2"
 
         async def coro3():
-            await asyncio.sleep(0.3)
             raise ServerError("Oops!", 503)
 
         provider = OpenStackProvider()


### PR DESCRIPTION
This modification will catch the Exception, to free all hosts and wait for quota to be available again