### PR TITLE
feat(outputs): merge nested dictionary instead of overriding it

### DIFF
--- a/src/mrack/outputs/pytest_mh.py
+++ b/src/mrack/outputs/pytest_mh.py
@@ -17,7 +17,7 @@
 import logging
 
 from mrack.outputs.utils import get_external_id, merge_dict
-from mrack.utils import get_fqdn, get_os_type, save_yaml
+from mrack.utils import get_fqdn, get_os_type, get_password, get_username, save_yaml
 
 DEFAULT_MHCFG_PATH = "pytest-mh.yaml"
 
@@ -71,6 +71,15 @@ class PytestMhOutput:
                         "host": get_external_id(provisioned_host, host, self._config),
                     },
                 }
+
+                if get_os_type(host) == "windows":
+                    username = get_username(provisioned_host, host, self._config)
+                    if username:
+                        hostcfg["ssh"]["username"] = username
+
+                    password = get_password(provisioned_host, host, self._config)
+                    if password:
+                        hostcfg["ssh"]["password"] = password
 
                 cfgdom["hosts"].append(merge_dict(hostcfg, host.get("pytest_mh", {})))
 

--- a/src/mrack/outputs/pytest_mh.py
+++ b/src/mrack/outputs/pytest_mh.py
@@ -16,7 +16,7 @@
 
 import logging
 
-from mrack.outputs.utils import get_external_id
+from mrack.outputs.utils import get_external_id, merge_dict
 from mrack.utils import get_fqdn, get_os_type, save_yaml
 
 DEFAULT_MHCFG_PATH = "pytest-mh.yaml"
@@ -61,21 +61,18 @@ class PytestMhOutput:
                     logger.error(f"Host {host['name']} not found in the database.")
                     continue
 
-                cfgdom["hosts"].append(
-                    {
-                        "hostname": get_fqdn(host["name"], domain.get("name", "")),
-                        "os": {
-                            "family": get_os_type(host),
-                        },
-                        "role": host["role"],
-                        "ssh": {
-                            "host": get_external_id(
-                                provisioned_host, host, self._config
-                            ),
-                        },
-                        **host.get("pytest_mh", {}),
-                    }
-                )
+                hostcfg = {
+                    "hostname": get_fqdn(host["name"], domain.get("name", "")),
+                    "os": {
+                        "family": get_os_type(host),
+                    },
+                    "role": host["role"],
+                    "ssh": {
+                        "host": get_external_id(provisioned_host, host, self._config),
+                    },
+                }
+
+                cfgdom["hosts"].append(merge_dict(hostcfg, host.get("pytest_mh", {})))
 
         return cfg
 

--- a/src/mrack/outputs/utils.py
+++ b/src/mrack/outputs/utils.py
@@ -14,6 +14,7 @@
 
 """Utility functions for output modules."""
 
+import copy
 import socket
 from socket import error as socket_error
 
@@ -45,3 +46,20 @@ def get_external_id(host, meta_host, config):
     if resolve_ip:
         external_id = resolve_hostname(host.ip_addr) or host.ip_addr
     return external_id
+
+
+def merge_dict(d1, d2):
+    """
+    Merge two nested dictionaries together.
+
+    Nested dictionaries are not overwritten but combined.
+    """
+    dest = copy.deepcopy(d1)
+    for key, value in d2.items():
+        if isinstance(value, dict):
+            dest[key] = merge_dict(dest.get(key, {}), value)
+            continue
+
+        dest[key] = value
+
+    return dest

--- a/tests/unit/test_pytest_mh.py
+++ b/tests/unit/test_pytest_mh.py
@@ -39,6 +39,9 @@ def mock_metadata():
         role: ipa
         os: fedora-37
         pytest_mh:
+          ssh:
+            username: tuser
+            password: tuserpassword
           config:
             client:
               ipa_domain: ipa.test
@@ -77,6 +80,8 @@ class TestPytestMhOutput:
             role: ipa
             ssh:
               host: 192.168.0.1
+              username: tuser
+              password: tuserpassword
             config:
               client:
                 ipa_domain: ipa.test

--- a/tests/unit/test_pytest_mh.py
+++ b/tests/unit/test_pytest_mh.py
@@ -47,6 +47,10 @@ def mock_metadata():
               ipa_domain: ipa.test
               krb5_keytab: /enrollment/ipa.keytab
               ldap_krb5_keytab: /enrollment/ipa.keytab
+      - name: dc.ad.test
+        group: ad
+        role: ad
+        os: windows-2016
     """
     )
 
@@ -55,6 +59,11 @@ class TestPytestMhOutput:
     def test_output(self, mock_metadata):
         config = provisioning_config()
         db = get_db_from_metadata(mock_metadata)
+
+        # Set username and password in the host object of Windows host,
+        # this should be reflected in the resulting configuration.
+        db.hosts["dc.ad.test"]._username = "Administrator"
+        db.hosts["dc.ad.test"]._password = "adpassword"
 
         mhcfg_output = PytestMhOutput(config, db, mock_metadata)
         mhcfg = mhcfg_output.create_mh_config()
@@ -87,7 +96,17 @@ class TestPytestMhOutput:
                 ipa_domain: ipa.test
                 krb5_keytab: /enrollment/ipa.keytab
                 ldap_krb5_keytab: /enrollment/ipa.keytab
+          - hostname: dc.ad.test
+            os:
+              family: windows
+            role: ad
+            ssh:
+              host: 192.168.0.1
+              username: Administrator
+              password: adpassword
         """
         )
+
+        print(mhcfg)
 
         assert mhcfg == expected


### PR DESCRIPTION
pytest-mh configuration may contain nested dictionary, specifying
username or password in pytest_mh section will result in overriding
the host option, i.e.:

```
pytest_mh:
  ssh:
    username: tuser
    password: tuserpassword
```

will generate wrong configuration where ssh/host is not set.

This patch makes sure that the ssh key is merged instead of overwritten.