### PR TITLE
chore: fix docs dependencies in tox run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 [testenv:docs]
 changedir = docs
 deps =
-    sphinx
+    -r{toxinidir}/docs/requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 basepython = python3.9


### PR DESCRIPTION
Running `make test` or `tox` failed on building docs as the tox config did not use the docsi/requirements.txt and thus the required dependency which was recently added was missing.

This path is changing the tox run to use the docs/requirements.txt and thus is fixing the issue.