### PR TITLE
feat: configurable ssh options

### DIFF
--- a/src/mrack/actions/ssh.py
+++ b/src/mrack/actions/ssh.py
@@ -20,7 +20,7 @@ from mrack.actions.action import Action
 from mrack.context import global_context
 from mrack.errors import ApplicationError
 from mrack.host import STATUS_ACTIVE
-from mrack.utils import get_username_pass_and_ssh_key
+from mrack.utils import get_ssh_options, get_username_pass_and_ssh_key
 from mrack.utils import ssh_to_host as utils_ssh_to_host
 
 try:
@@ -87,12 +87,16 @@ class SSH(Action):
         username, password, ssh_key = get_username_pass_and_ssh_key(
             host, global_context
         )
+        ssh_options = get_ssh_options(
+            host, global_context.METADATA, global_context.PROV_CONFIG
+        )
         return utils_ssh_to_host(
             host,
             username=username,
             password=password,
             ssh_key=ssh_key,
             interactive=True,
+            ssh_options=ssh_options,
         )
 
     def is_container_env(self, host):

--- a/src/mrack/config.py
+++ b/src/mrack/config.py
@@ -42,6 +42,10 @@ class ProvisioningConfig:
         """Get item from raw representation."""
         return self._raw[key]
 
+    def __setitem__(self, key, value):
+        """Set provisioning config item."""
+        self._raw[key] = value
+
     def get(self, key, default=None):
         """Get method as in dict for raw config."""
         return self._raw.get(key, default)

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -27,9 +27,11 @@ from mrack.utils import (
     get_password,
     get_shortname,
     get_ssh_key,
+    get_ssh_options,
     get_username,
     is_windows_host,
     save_yaml,
+    ssh_options_to_cli,
 )
 
 DEFAULT_INVENTORY_PATH = "mrack-inventory.yaml"
@@ -137,6 +139,7 @@ class AnsibleInventoryOutput:
         ansible_user = get_username(db_host, meta_host, self._config)
         password = get_password(db_host, meta_host, self._config)
         ssh_key = get_ssh_key(db_host, meta_host, self._config)
+        ssh_options = get_ssh_options(db_host, self._metadata, self._config)
         dom_name = meta_domain["name"]
 
         # Common attributes
@@ -165,6 +168,10 @@ class AnsibleInventoryOutput:
 
         if ssh_key:
             host_info["ansible_ssh_private_key_file"] = os.path.abspath(ssh_key)
+
+        if ssh_options:
+            ssh_common_args = " ".join(ssh_options_to_cli(ssh_options))
+            host_info["ansible_ssh_common_args"] = ssh_common_args
 
         if password:
             host_info["ansible_password"] = password

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -22,7 +22,12 @@ from datetime import datetime, timedelta
 from mrack.context import global_context
 from mrack.errors import ProvisioningError
 from mrack.host import STATUS_ACTIVE, STATUS_OTHER, Host
-from mrack.utils import get_username_pass_and_ssh_key, object2json, ssh_to_host
+from mrack.utils import (
+    get_ssh_options,
+    get_username_pass_and_ssh_key,
+    object2json,
+    ssh_to_host,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -128,12 +133,16 @@ class Provider:
         )
 
         while True:
+            ssh_options = get_ssh_options(
+                host, global_context.METADATA, global_context.PROV_CONFIG
+            )
             res = ssh_to_host(
                 host,
                 username=username,
                 password=password,
                 ssh_key=ssh_key,
                 command="echo mrack",
+                ssh_options=ssh_options,
             )
             duration = (datetime.now() - start_ssh).total_seconds()
 

--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -39,7 +39,7 @@ def create_metadata(ipaservers, ipaclients, ads):
 
     for i in range(ipaservers):
         host = {
-            "name": f"ipaserver{i}@{domain_name}",
+            "name": f"ipaserver{i}.{domain_name}",
             "os": fedora,
             "role": "ipaserver",
             "groups": ["ipaserver"],
@@ -48,7 +48,7 @@ def create_metadata(ipaservers, ipaclients, ads):
 
     for i in range(ipaclients):
         host = {
-            "name": f"ipaclient{i}@{domain_name}",
+            "name": f"ipaclient{i}.{domain_name}",
             "os": fedora,
             "role": "ipaclient",
             "groups": ["ipaclient"],
@@ -64,7 +64,7 @@ def create_metadata(ipaservers, ipaclients, ads):
 
     for i in range(ads):
         host = {
-            "name": f"ad{i}@{addomain_name}",
+            "name": f"ad{i}.{addomain_name}",
             "os": "windows",
             "role": "ad",
             "groups": ["win-2019"],

--- a/tests/unit/test_ansible_inventory.py
+++ b/tests/unit/test_ansible_inventory.py
@@ -160,7 +160,7 @@ class TestAnsibleInventory:
             "hosts" in inventory["all"]["children"]["client"]["children"]["ipaclient"]
         )
         assert (
-            "ipaclient0@example.test"
+            "ipaclient0.example.test"
             in inventory["all"]["children"]["client"]["children"]["ipaclient"]["hosts"]
         )
 
@@ -172,7 +172,7 @@ class TestAnsibleInventory:
             "hosts" in inventory["all"]["children"]["server"]["children"]["ipaserver"]
         )
         assert (
-            "ipaserver0@example.test"
+            "ipaserver0.example.test"
             in inventory["all"]["children"]["server"]["children"]["ipaserver"]["hosts"]
         )
 
@@ -546,3 +546,21 @@ class TestAnsibleInventory:
         assert "something_else" in d1_srv2
         assert d1_srv2["no_ca"] == "no"
         assert d1_srv2["something_else"] == "default_global"
+
+    def test_host_ssh_options(self, metadata, db):
+        prov_config = provisioning_config()
+        ans_inv = AnsibleInventoryOutput(prov_config, db, metadata)
+
+        # Test Default behavior
+        inventory = ans_inv.create_inventory()
+        srv1 = inventory["all"]["hosts"]["ipaserver0.example.test"]
+        assert "ansible_ssh_common_args" in srv1
+
+        expected = "-o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null'"
+        assert srv1["ansible_ssh_common_args"] == expected
+
+        # Test when there are not options
+        prov_config["ssh"] = {"options": {}}
+        inventory = ans_inv.create_inventory()
+        srv1 = inventory["all"]["hosts"]["ipaserver0.example.test"]
+        assert "ansible_ssh_common_args" not in srv1


### PR DESCRIPTION
This implements configurable ssh options according to design:

https://mrack.readthedocs.io/en/latest/designs/ssh_options.html

With the idea that those options will be used for SSH connections check as well as added to generated Ansible inventory so that other tools can use it.