### PR TITLE
chore(release): Add PyPI action & extract copr step

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -31,7 +31,7 @@ jobs:
         run: tox -e py
 
   release:
-    name: mrack semantic release
+    name: mrack semantic release 🐕
     runs-on: ubuntu-latest
     needs: [pre-commit, test]
     if: github.repository == 'neoave/mrack'
@@ -58,8 +58,8 @@ jobs:
           fetch-depth: 0
       - name: Get the new version using python-semantic-release
         run: |
-          pip3 install python-semantic-release==7.34.4
-          echo "NEW_VERSION="`semantic-release print-version --noop` >> ${GITHUB_ENV}
+          pip3 install python-semantic-release==8.0.8
+          echo "NEW_VERSION="`semantic-release version --print` >> ${GITHUB_ENV}
       - name: Update the mrack.spec changelog with initiator and basic message
         run: |
           # get the history of commits and generate changelog from it
@@ -75,12 +75,70 @@ jobs:
           sed -ri \
           "s/\%changelog/\%changelog\\n\*\ $TODAY\ $RELEASE_ACTOR\ -\ $NEW_VERSION-1/" \
           mrack.spec
+      - name: Add version to specfile
+        run: |
+          export SPEC_VERSION_REGEX="s/^Version:(\s+)(.*)/Version:\1$NEW_VERSION/"
+          echo $SPEC_VERSION_REGEX
+          sed -i -E $SPEC_VERSION_REGEX mrack.spec
       - name: Add specfile to commit
         run: git add mrack.spec
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.34.4
+        uses: relekang/python-semantic-release@v8.0.8
         with:
           github_token: ${{ secrets.TIBORIS_GH_TOKEN }}
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
+
+  copr-build:
+    name: Copr 📦 build for mrack
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
       - name: Trigger COPR build
         run: curl -X POST ${{ secrets.COPR_WEBHOOK_URL }}
+
+  python-build:
+    name: Build 🐍 distribution 📦
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish 🐍 distribution 📦 to PyPI
+    # only publish to PyPI on tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [python-build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mrack/
+    # IMPORTANT: mandatory for trusted publishing which is setup on pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists from artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: list dist dir
+        run: ls -la dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,10 @@ pythonpath = [
 
 [tool.semantic_release]
 version_source = "commit"
-commit_subject = "chore: Release version {version}"
-commit_message = "Releasing mrack version {version}"
-version_variable = [
+commit_message = "chore: Release version {version}\n\nReleasing new mrack version"
+version_variables = [
     "src/mrack/version.py:VERSION",
     "docs/conf.py:release",
-]
-version_pattern = [
-    "mrack.spec:Version:\\s+{version}",
 ]
 branch = "main"
 commit = true


### PR DESCRIPTION
Due to latest changes to python semantic release
PyPI release is no longer supported and the separate action (https://github.com/pypa/gh-action-pypi-publish) is recomended to use while releasing to PyPI.
For the trusted publishing we had to set up the PyPI account owning mrack to trust neoave/mrack repository which I did and set up the actions jobs to build
the python package and trigger a truster build.
As an addition i have extracted copr to separate job.