### PR TITLE
chore(ci): Fix release workflow build step checking out wrong commit

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -101,6 +101,10 @@ jobs:
     needs: [release]
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout latest release commit
+        run: |
+          git fetch
+          git checkout $(git rev-parse FETCH_HEAD)
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
actions/checkout checks out the latest commit at the time of the workflow trigger, 
hence any commit done during the workflow is not included. 
Fixing this to checkout the actual latest (release) commit.