### PR TITLE
chore(release): Fix fedora release

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
       - name: Get the new version using python-semantic-release
         run: |
-          pip3 install python-semantic-release==8.0.8
+          pip3 install python-semantic-release==8.1.1
           echo "NEW_VERSION="`semantic-release version --print` >> ${GITHUB_ENV}
       - name: Update the mrack.spec changelog with initiator and basic message
         run: |
@@ -85,7 +85,7 @@ jobs:
       - name: Add specfile to commit
         run: git add mrack.spec
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v8.0.8
+        uses: python-semantic-release/python-semantic-release@v8.1.1
         with:
           github_token: ${{ secrets.TIBORIS_GH_TOKEN }}
       - name: Set NEW_VERSION as output


### PR DESCRIPTION
- [chore(release): Upload distribution package to release assets](https://github.com/neoave/mrack/commit/a0f53725ce0cd40051ee630ad8e9ca11fff7c95e)
        
        To fix fedora release, broken in https://github.com/neoave/mrack/pull/272
        
        Fixes https://github.com/neoave/mrack/issues/273

- [chore(release): Update semantic release action name and version](https://github.com/neoave/mrack/commit/7a069f2a2eb474ae27cc9c432d0dc8a00719a57a)

        
          Updating action to new name and latest version.
          This should not affect behaviour.