### PR TITLE
fix: curate_auth_url func changed to non-async

### DIFF
--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -121,7 +121,7 @@ class OpenStackProvider(Provider):
 
         return result
 
-    async def _curate_auth_url(self, auth_url):
+    def _curate_auth_url(self, auth_url):
         """Append OpenStack API version if not present."""
         return auth_url if auth_url.endswith("/v3") else auth_url + "/v3"
 

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -898,8 +898,7 @@ class TestOpenStackProvider:
             ("http://example.com/openstack/v3", "http://example.com/openstack/v3"),
         ],
     )
-    @pytest.mark.asyncio
-    async def test_curate_auth_url(self, input_auth_url, expected_auth_url):
+    def test_curate_auth_url(self, input_auth_url, expected_auth_url):
         provider = OpenStackProvider()
-        result_auth_url = await provider._curate_auth_url(input_auth_url)
+        result_auth_url = provider._curate_auth_url(input_auth_url)
         assert result_auth_url == expected_auth_url


### PR DESCRIPTION
await call for _curate_auth_url missing in session creation which caused regression.
function _curate_auth_url changed to non-async, tests updated to reflect the same