### PR TITLE
fix(beaker): suppress 10_avc_check restraint plugin

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -204,7 +204,11 @@ class BeakerProvider(Provider):
         recipe.addReservesys(duration=str(self.reserve_duration))
 
         for task in specs["tasks"]:
-            recipe.addTask(task=task["name"], role=task["role"])
+            recipe.addTask(
+                task=task["name"],
+                role=task["role"],
+                taskParams=task.get("params"),
+            )
 
         # Create RecipeSet and add our Recipe to it.
         recipe_set = BeakerRecipeSet(**specs)

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -181,7 +181,13 @@ class BeakerTransformer(Transformer):
                 "tasks",
                 host["os"],
                 default=[  # we use dummy task because beaker require a task in recipe
-                    {"name": "/distribution/dummy", "role": "STANDALONE"}
+                    {
+                        "name": "/distribution/dummy",
+                        "role": "STANDALONE",
+                        "params": [
+                            "RSTRNT_DISABLED=10_avc_check",
+                        ],
+                    }
                 ],
             ),
             "ks_append": self._construct_ks_append_script(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import socket
 import tempfile
 from pathlib import Path
 
@@ -45,3 +46,20 @@ def cleandir():
     yield
     os.chdir(old_cwd)
     shutil.rmtree(newpath)
+
+
+@pytest.fixture
+def mock_gethostbyaddr(monkeypatch):
+    """
+    Mock gethostbyaddr function from socket module.
+
+    It returns only IP address as if the DNS resolution would fail - which it does
+    for test data anyway.
+
+    This is to speed up the tests
+    """
+
+    def gethostbyaddr(ip_address):
+        return [ip_address, [], []]
+
+    monkeypatch.setattr(socket, "gethostbyaddr", gethostbyaddr)

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -26,7 +26,12 @@ def global_context_init(provisioning_config_file, mrack_config_file=None, db_fil
 class TestStaticProvider:
     @pytest.mark.asyncio
     async def test_up_action(
-        self, provisioning_config, metadata, database, setup_providers
+        self,
+        provisioning_config,
+        metadata,
+        database,
+        setup_providers,
+        mock_gethostbyaddr,
     ):
         up_action = UpAction(
             config=provisioning_config,
@@ -88,6 +93,7 @@ class TestStaticProvider:
         cleandir,
         config,
         files,
+        mock_gethostbyaddr,
     ):
         workdir = os.getcwd()
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
@@ -185,3 +186,20 @@ def host1_osp(metahost1):
 @pytest.fixture
 def host_win_aws(metahost_win):
     return meta_to_host(metahost_win, "aws", "3", "192.168.0.129")
+
+
+@pytest.fixture
+def mock_gethostbyaddr(monkeypatch):
+    """
+    Mock gethostbyaddr function from socket module.
+
+    It returns only IP address as if the DNS resolution would fail - which it does
+    for test data anyway.
+
+    This is to speed up the tests
+    """
+
+    def gethostbyaddr(ip_address):
+        return [ip_address, [], []]
+
+    monkeypatch.setattr(socket, "gethostbyaddr", gethostbyaddr)

--- a/tests/unit/test_beaker_transformer.py
+++ b/tests/unit/test_beaker_transformer.py
@@ -16,7 +16,15 @@ class TestBeakerTransformer:
     cat_release = "cat /etc/redhat-release"
     wget = "wget redhat.com"
     default_whiteboard = "This job has been created using mrack."
-    default_tasks = [{"name": "/distribution/dummy", "role": "STANDALONE"}]
+    default_tasks = [
+        {
+            "name": "/distribution/dummy",
+            "role": "STANDALONE",
+            "params": [
+                "RSTRNT_DISABLED=10_avc_check",
+            ],
+        }
+    ]
     default_retention_tag = "audit"
     default_product = "[internal]"
 

--- a/tests/unit/test_pytest_mh.py
+++ b/tests/unit/test_pytest_mh.py
@@ -56,7 +56,7 @@ def mock_metadata():
 
 
 class TestPytestMhOutput:
-    def test_output(self, mock_metadata):
+    def test_output(self, mock_metadata, mock_gethostbyaddr):
         config = provisioning_config()
         db = get_db_from_metadata(mock_metadata)
 

--- a/tests/unit/test_pytest_multihost.py
+++ b/tests/unit/test_pytest_multihost.py
@@ -4,7 +4,7 @@ from .mock_data import get_db_from_metadata, metadata_extra, provisioning_config
 
 
 class TestPytestMultihostOutput:
-    def test_arbitrary_attrs(self):
+    def test_arbitrary_attrs(self, mock_gethostbyaddr):
         """
         Test that values defined in `pytest_multihost` dictionary in host part
         of job metadata file gets into host attributes in generated pytest-multihost
@@ -40,7 +40,7 @@ class TestPytestMultihostOutput:
         assert srv2["no_ca"] == "yes"
         assert srv2["something_else"] == "for_fun"
 
-    def test_config_section_deleted(self):
+    def test_config_section_deleted(self, mock_gethostbyaddr):
         """
         Test that config section from metadata is not included in mhc.yaml.
         """


### PR DESCRIPTION
**fix(beaker): suppress 10_avc_check restraint plugin**

It has happpened that this plugin sometimes ran after the dummy task, it reported fail
that there was some AVC (probabaly from other thing) which then failed the job and thus
mrack treated this as a provisioning failure.

This patch instructs restraint to not run this plugin and thus avoid this situation.

**test: speed-up tests by mocking gethostbyaddr**

Tests that are using mrack outputs are slowed down by
socker.gethostbyaddr for adhoc IP addresses. This resolution mostly
fails and the test is slow (multiple seconds timeout for single IP).

With this, all python tests are executed within 1.5s.

**Notes**
The other patch  was created so that I can run the tests locally effectively. 
