### PR TITLE
chore: Update deprecated actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,8 +10,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -8,8 +8,8 @@ jobs:
     name: run pre-commit hook
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - uses: pre-commit/action@v3.0.0
@@ -20,9 +20,9 @@ jobs:
     steps:
       - name: Install krb5-config libvirt-dev  # missing distro dependencies
         run: sudo apt update && sudo apt-get install libkrb5-dev libvirt-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install Tox and any other packages
@@ -38,7 +38,7 @@ jobs:
     outputs:
       new_version: ${{ steps.set_version.outputs.new_version }}
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Display Python version
@@ -54,7 +54,7 @@ jobs:
         run: |
           RELEASE_ACTOR=RELEASE_ACTOR_$(echo ${GITHUB_ACTOR^^} | tr - _)
           echo "RELEASE_ACTOR=${!RELEASE_ACTOR}" >> ${GITHUB_ENV}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false  # do not set the actions user to git config
           fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
           git fetch
           git checkout $(git rev-parse FETCH_HEAD)
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install pypa/build
@@ -123,7 +123,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -145,7 +145,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the dists from artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
Due to warnings shown in https://github.com/neoave/mrack/actions/runs/9302766806

It updates actions to new version with Node 20