### PR TITLE
feat: update pytest-mh output to work with latest version

### DIFF
--- a/src/mrack/outputs/pytest_mh.py
+++ b/src/mrack/outputs/pytest_mh.py
@@ -67,7 +67,8 @@ class PytestMhOutput:
                         "family": get_os_type(host),
                     },
                     "role": host["role"],
-                    "ssh": {
+                    "conn": {
+                        "type": "ssh",
                         "host": get_external_id(provisioned_host, host, self._config),
                     },
                 }
@@ -75,11 +76,11 @@ class PytestMhOutput:
                 if get_os_type(host) == "windows":
                     username = get_username(provisioned_host, host, self._config)
                     if username:
-                        hostcfg["ssh"]["username"] = username
+                        hostcfg["conn"]["username"] = username
 
                     password = get_password(provisioned_host, host, self._config)
                     if password:
-                        hostcfg["ssh"]["password"] = password
+                        hostcfg["conn"]["password"] = password
 
                 cfgdom["hosts"].append(merge_dict(hostcfg, host.get("pytest_mh", {})))
 

--- a/tests/unit/test_pytest_mh.py
+++ b/tests/unit/test_pytest_mh.py
@@ -39,7 +39,8 @@ def mock_metadata():
         role: ipa
         os: fedora-37
         pytest_mh:
-          ssh:
+          conn:
+            type: ssh
             username: tuser
             password: tuserpassword
           config:
@@ -77,7 +78,8 @@ class TestPytestMhOutput:
             os:
               family: linux
             role: client
-            ssh:
+            conn:
+              type: ssh
               host: 192.168.0.1
             artifacts:
             - /etc/sssd/*
@@ -87,7 +89,8 @@ class TestPytestMhOutput:
             os:
               family: linux
             role: ipa
-            ssh:
+            conn:
+              type: ssh
               host: 192.168.0.1
               username: tuser
               password: tuserpassword
@@ -100,7 +103,8 @@ class TestPytestMhOutput:
             os:
               family: windows
             role: ad
-            ssh:
+            conn:
+              type: ssh
               host: 192.168.0.1
               username: Administrator
               password: adpassword


### PR DESCRIPTION
pytest-mh implemented a generic connection interface so one
can choose between ssh, podman and docker. This introduced
a breaking change in the configuration.

The `ssh` field was changed to a generic `conn` field that
specifies the connection type.

More information can be found in the pytest-mh pull request.

Depends on:
* https://github.com/next-actions/pytest-mh/pull/67