### PR TITLE
chore: Enable epel-10 builds in Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -45,7 +45,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     release_suffix: "99.dev.{PACKIT_PROJECT_BRANCH}"
-    targets: [fedora-all, epel-8, epel-9]
+    targets: [fedora-all, epel-all]
 
   - job: tests
     trigger: pull_request
@@ -54,25 +54,25 @@ jobs:
 
   - job: copr_build
     trigger: commit
-    targets: [fedora-all, epel-8, epel-9]
+    targets: [fedora-all, epel-all]
 
   - job: copr_build
     trigger: release
     owner: "@freeipa"
     project: neoave
-    targets: [fedora-all, epel-8, epel-9]
+    targets: [fedora-all, epel-all]
 
   - job: propose_downstream
     trigger: release
-    dist_git_branches: [fedora-all, epel-8, epel-9]
+    dist_git_branches: [fedora-all, epel-all]
 
   - job: koji_build
     trigger: commit
-    dist_git_branches: [fedora-all, epel-8, epel-9]
+    dist_git_branches: [fedora-all, epel-all]
 
   - job: bodhi_update
     trigger: commit
-    dist_git_branches: [fedora-branched, epel-8, epel-9] # rawhide updates are created automatically
+    dist_git_branches: [fedora-branched, epel-all] # rawhide updates are created automatically
 
 #   # pr_osp
 #   - &internal_test  # use openstack (osp) tests as template for other test cases


### PR DESCRIPTION
Replace epel-8/9 with epel-all which points to all current releases, including epel-10