### PR TITLE
fix: Increase winrm timeouts for better stability

### DIFF
--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -193,6 +193,8 @@ class AnsibleInventoryOutput:
                     "ansible_connection": "winrm",
                     "ansible_winrm_server_cert_validation": "ignore",
                     "meta_domain_level": meta_host.get("domain_level", "top"),
+                    "ansible_winrm_read_timeout_sec": 600,
+                    "ansible_winrm_operation_timeout_sec": 300,
                 }
             )
 


### PR DESCRIPTION
Increase winrm timeouts so machines are more resilient to "Unrechable" state.