### PR TITLE
chore(packit): Update epel spec for fedora propose upstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -45,7 +45,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     release_suffix: "99.dev.{PACKIT_PROJECT_BRANCH}"
-    targets: [fedora-all, epel-all]
+    targets: [fedora-all, epel-9, epel-10]
 
   - job: tests
     trigger: pull_request
@@ -54,25 +54,25 @@ jobs:
 
   - job: copr_build
     trigger: commit
-    targets: [fedora-all, epel-all]
+    targets: [fedora-all, epel-9, epel-10]
 
   - job: copr_build
     trigger: release
     owner: "@freeipa"
     project: neoave
-    targets: [fedora-all, epel-all]
+    targets: [fedora-all, epel-9, epel-10]
 
   - job: propose_downstream
     trigger: release
-    dist_git_branches: [fedora-all, epel-all]
+    dist_git_branches: [fedora-all, epel-9, epel-10]
 
   - job: koji_build
     trigger: commit
-    dist_git_branches: [fedora-all, epel-all]
+    dist_git_branches: [fedora-all, epel-9, epel-10]
 
   - job: bodhi_update
     trigger: commit
-    dist_git_branches: [fedora-branched, epel-all] # rawhide updates are created automatically
+    dist_git_branches: [fedora-branched, epel-9, epel-10] # rawhide updates are created automatically
 
 #   # pr_osp
 #   - &internal_test  # use openstack (osp) tests as template for other test cases


### PR DESCRIPTION
Use epel major version instead of epel-all to avoid releasing to minor branches (e.g. epel10.0) and drop epel8 (supported dropped in tmt)