### PR TITLE
chore: Bump python-semantic-release to fix release issue

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
       - name: Get the new version using python-semantic-release
         run: |
-          pip3 install python-semantic-release==8.1.1
+          pip3 install python-semantic-release==10.3.1
           echo "NEW_VERSION="`semantic-release version --print` >> ${GITHUB_ENV}
       - name: Update the mrack.spec changelog with initiator and basic message
         run: |
@@ -85,7 +85,7 @@ jobs:
       - name: Add specfile to commit
         run: git add mrack.spec
       - name: Python Semantic Release
-        uses: python-semantic-release/python-semantic-release@v8.1.1
+        uses: python-semantic-release/python-semantic-release@v10.3.1
         with:
           github_token: ${{ secrets.TIBORIS_GH_TOKEN }}
       - name: Set NEW_VERSION as output


### PR DESCRIPTION
Python release was failing due to a dep issue when building python-semantic-release action image. e.g. https://github.com/neoave/mrack/actions/runs/16966276988

Upgrading to 10.3.1 to fix it

Breaking changes don't affect our implementation.

Fixes: https://github.com/neoave/mrack/issues/321 

