### PR TITLE
feat: Add support to pass watchdog panic="ignore"

### DIFF
--- a/src/mrack/providers/beaker.py
+++ b/src/mrack/providers/beaker.py
@@ -194,6 +194,14 @@ class BeakerProvider(Provider):
         # Add ReserveSys element to reserve system after provisioning
         recipe.addReservesys(duration=str(self.reserve_duration))
 
+        # Add watchdog element if configured
+        watchdog_config = specs.get("watchdog")
+        if watchdog_config and isinstance(watchdog_config, dict):
+            watchdog_node = xml_doc().createElement("watchdog")
+            for key, value in watchdog_config.items():
+                watchdog_node.setAttribute(key, str(value))
+            recipe.node.appendChild(watchdog_node)
+
         for task in specs["tasks"]:
             recipe.addTask(
                 task=task["name"],

--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -281,6 +281,12 @@ class BeakerTransformer(Transformer):
                 distro,
                 default=[],
             ),
+            "watchdog": self._find_value(
+                host.get(CONFIG_KEY, {}),
+                "watchdog",
+                "watchdog",
+                host["os"],
+            ),
         }
 
         return specs

--- a/tests/unit/test_beaker.py
+++ b/tests/unit/test_beaker.py
@@ -92,6 +92,37 @@ class TestBeakerProvider:
         # so that provisioning won't fail on AVC denials
         xml = job.toxml()
         assert '<param name="RSTRNT_DISABLED" value="10_avc_check"/>' in xml
+        assert "<watchdog" not in xml
+
+    @pytest.mark.asyncio
+    async def test_beaker_job_creation_with_watchdog(self, mock_beaker_conf):
+        # Given initialized beaker provider and transformer with real beaker
+        # calls mocked
+        providers.register("beaker", BeakerProvider)
+        provider = providers.get("beaker")
+        await provider.init(self.distros, self.timeout, self.reserve_duration)
+        bkr_transformer = MockedBeakerTransformer()
+
+        await bkr_transformer.init(provisioning_config(), {})
+        bkr_transformer.add_host(
+            {
+                "name": "host-watchdog.example.test",
+                "group": "client",
+                "os": "Fedora-31%",
+                "beaker": {
+                    "watchdog": {"panic": "ignore"},
+                },
+            }
+        )
+
+        # When having a host requirement with watchdog config
+        # and creating a Beaker job
+        req = bkr_transformer.create_host_requirements()[0]
+        job = provider._req_to_bkr_job(req)
+
+        # Then the job contains watchdog element
+        xml = job.toxml()
+        assert '<watchdog panic="ignore"/>' in xml
 
     def test_translate_constraint_basic_operands(self, mock_beaker_conf):
         """Test _translate_constraint with basic operands (no and/or)."""

--- a/tests/unit/test_beaker_transformer.py
+++ b/tests/unit/test_beaker_transformer.py
@@ -129,6 +129,7 @@ class TestBeakerTransformer:
                 cat_release,
                 wget,
             ],
+            "watchdog": {"panic": "ignore"},
         },
     }
 
@@ -207,6 +208,7 @@ class TestBeakerTransformer:
                     ],
                     "retention_tag": default_retention_tag,
                     "product": default_product,
+                    "watchdog": None,
                 },
             ),
             (
@@ -222,6 +224,7 @@ class TestBeakerTransformer:
                     "retention_tag": "active",
                     "product": "cpe:/a:redhat:jboss_operations_network:2.3",
                     "tasks": [{"name": "/distribution/sleep", "role": "STANDALONE"}],
+                    "watchdog": None,
                 },
             ),
             (
@@ -237,6 +240,7 @@ class TestBeakerTransformer:
                     "tasks": default_tasks,
                     "retention_tag": default_retention_tag,
                     "product": default_product,
+                    "watchdog": None,
                 },
             ),
             (
@@ -252,6 +256,7 @@ class TestBeakerTransformer:
                     "tasks": default_tasks,
                     "retention_tag": "scratch",
                     "product": "",
+                    "watchdog": None,
                 },
             ),
             # default variant should be there,
@@ -269,6 +274,7 @@ class TestBeakerTransformer:
                     "tasks": default_tasks,
                     "retention_tag": default_retention_tag,
                     "product": default_product,
+                    "watchdog": None,
                 },
             ),
             (
@@ -286,6 +292,7 @@ class TestBeakerTransformer:
                     "tasks": default_tasks,
                     "retention_tag": default_retention_tag,
                     "product": default_product,
+                    "watchdog": {"panic": "ignore"},
                 },
             ),
         ],
@@ -308,6 +315,7 @@ class TestBeakerTransformer:
             "tasks",
             "retention_tag",
             "product",
+            "watchdog",
         ]
         bkr_transformer = await self.create_transformer()
         req = bkr_transformer.create_host_requirement(meta_host)
@@ -337,3 +345,16 @@ class TestBeakerTransformer:
         req = bkr_transformer.create_host_requirement(meta_host)
         assert req.get("distro") == exp_distro
         assert req.get("variant") == exp_variant
+
+    @pytest.mark.asyncio
+    async def test_watchdog_configuration(self):
+        """Test watchdog configuration is properly handled"""
+        bkr_transformer = await self.create_transformer()
+
+        # Test with watchdog config
+        req_watchdog = bkr_transformer.create_host_requirement(self.rhel86)
+        assert req_watchdog.get("watchdog") == {"panic": "ignore"}
+
+        # Test with no watchdog config
+        req_none = bkr_transformer.create_host_requirement(self.fedora)
+        assert req_none.get("watchdog") is None


### PR DESCRIPTION
Add support to pass watchdog panic="ignore" in Beaker recipe.
Add unit tests for beaker-watchdog panic=ignore recipe option.

I have tested this branch with the soon-to-be-proposed `tmt` changes.

Fixes: `tmt` issue [#4004](https://github.com/teemtee/tmt/issues/4004).

Assisted by: Cursor AI