### PR TITLE
feat: add EC2 UserData support for AWS provider

### DIFF
--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -54,6 +54,8 @@ aws:  # aws provider config
     images:
         # list of ami images key is used in metadata ami image is used for provider e.g.
         fedora-32: ami-0f1d60751946b66c5  # Fedora-Cloud-Base-32-1.6.x86_64-hvm-eu-central-1-gp2-0
+        win-2019: ami-0123456789abcdef0 # find Windows AMI by image id
+        win-2022: ami-9876543210fedcs23
         rhel-8.5:  # find AMI by tag name and value
             tag:
                 name: my-tag
@@ -85,7 +87,23 @@ aws:  # aws provider config
 
     users:
         rhel-8.5: ec2-user  # per-provider default user name override
+        win-2019: Administrator
+        win-2022: Administrator
 
+    # EC2 UserData passed to instances at launch, per OS image
+    # Useful for Windows instances (e.g. enabling OpenSSH, setting admin password)
+    user_data:
+        win-2019: &win_user_data |
+            <powershell>
+            # Set Administrator password (matches ad_admin_password in mhcfg)
+            net user Administrator Secret123
+
+            # Enable and start OpenSSH server
+            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+            Start-Service sshd
+            Set-Service -Name sshd -StartupType Automatic
+            </powershell>
+        win-2022: *win_user_data
 
 beaker:  # beaker provider specific values
     # feature to switch provisioning strategy from abort or retry on fail

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -397,6 +397,9 @@ class AWSProvider(Provider):
                 "MarketType": "spot",
             }
 
+        if specs.get("user_data"):
+            request["UserData"] = specs["user_data"]
+
         try:
             aws_res = self.ec2.create_instances(**request)
         except ClientError as creation_error:

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -110,6 +110,7 @@ class AWSTransformer(Transformer):
             "spot": self._find_value(host, "spot", None, None),
             "delete_volume_on_termination": del_vol,
             "subnet_ids": self._find_subnet_ids(host),
+            "user_data": self._find_value(host, "user_data", "user_data", host["os"]),
         }
 
         req = self.update_metadata_for_owner_lifetime(req)

--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -3,7 +3,16 @@ import uuid
 from mrack.config import ProvisioningConfig
 from mrack.dbdrivers.file import FileDBDriver
 from mrack.host import STATUS_ACTIVE, Host
+from mrack.transformers.aws import AWSTransformer
 from mrack.transformers.beaker import BeakerTransformer
+
+
+class MockedAWSTransformer(AWSTransformer):
+    """Mock AWS transformer."""
+
+    async def init_provider(self):
+        """Override the init_provider to do nothing."""
+        self.dsp_name = "AWS"
 
 
 class MockedBeakerTransformer(BeakerTransformer):

--- a/tests/unit/test_aws_transformer.py
+++ b/tests/unit/test_aws_transformer.py
@@ -1,0 +1,176 @@
+"""Tests for AWS Transformer - EC2 UserData support."""
+
+from copy import deepcopy
+
+import pytest
+
+from mrack.config import ProvisioningConfig
+from mrack.providers import providers
+from mrack.providers.aws import PROVISIONER_KEY as AWS
+from mrack.providers.aws import AWSProvider
+
+from .mock_data import MockedAWSTransformer
+
+DOMAIN = "example.test"
+
+WIN_2019_USER_DATA = (
+    "<powershell>\n"
+    "$admin = [adsi]('WinNT://./administrator, user')\n"
+    "$admin.PSBase.Invoke('SetPassword', 'Secret123')\n"
+    "</powershell>"
+)
+
+WIN_2022_USER_DATA = (
+    "<powershell>\n"
+    "net user Administrator Secret123\n"
+    "Restart-Service sshd\n"
+    "</powershell>"
+)
+
+
+def _host(name, role, group, os, user_data=None):
+    """Create a host metadata dict."""
+    host = {"name": f"{name}.{DOMAIN}", "role": role, "group": group, "os": os}
+    if user_data is not None:
+        host["user_data"] = user_data
+    return host
+
+
+def _aws_provisioning_config(user_data=None):
+    """Get provisioning config with AWS section for testing."""
+    aws_cfg = {
+        "images": {
+            "rhel-8.5": "ami-rhel-8-5",
+            "win-2019": "ami-win-2019",
+            "win-2022": "ami-win-2022",
+        },
+        "flavors": {
+            "ipaserver": "t2.medium",
+            "ad": "t2.medium",
+            "default": "t2.nano",
+        },
+        "keypair": "mrack-keypair.pem",
+        "security_group": "sg-something",
+        "security_groups": ["sg-something"],
+        "credentials_file": "aws.key",
+        "profile": "default",
+        "spot": True,
+        "instance_tags": {
+            "Name": "mrack-runner",
+            "mrack": "True",
+            "Persistent": "False",
+        },
+    }
+    if user_data is not None:
+        aws_cfg["user_data"] = deepcopy(user_data)
+
+    return ProvisioningConfig(
+        {
+            "aws": aws_cfg,
+            "users": {
+                "rhel-8.5": "cloud-user",
+                "win-2019": "Administrator",
+                "win-2022": "Administrator",
+            },
+        }
+    )
+
+
+class TestAWSTransformerUserData:
+    """Test the AWS Transformer's user_data handling."""
+
+    @pytest.mark.asyncio
+    async def _create_transformer(self, user_data=None):
+        """Initialize the AWS transformer with mocked provider."""
+        providers.register(AWS, AWSProvider)
+        transformer = MockedAWSTransformer()
+        config = _aws_provisioning_config(user_data=user_data)
+        hosts = [
+            _host("server", "master", "ipaserver", "rhel-8.5"),
+            _host("ad", "ad", "ad", "win-2019"),
+            _host("ad2", "ad", "ad", "win-2022"),
+        ]
+        metadata = {"domains": [{"name": DOMAIN, "type": "mixed", "hosts": hosts}]}
+        await transformer.init(config, metadata)
+        return transformer
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "config_user_data, meta_host, expected_user_data",
+        [
+            pytest.param(
+                {"win-2019": WIN_2019_USER_DATA},
+                _host("ad", "ad", "ad", "win-2019"),
+                WIN_2019_USER_DATA,
+                id="from_provisioning_config",
+            ),
+            pytest.param(
+                None,
+                _host("ad", "ad", "ad", "win-2019", user_data=WIN_2019_USER_DATA),
+                WIN_2019_USER_DATA,
+                id="from_host_metadata",
+            ),
+            pytest.param(
+                {"win-2019": "<powershell>echo config</powershell>"},
+                _host("ad", "ad", "ad", "win-2019", user_data=WIN_2019_USER_DATA),
+                WIN_2019_USER_DATA,
+                id="host_metadata_overrides_config",
+            ),
+            pytest.param(
+                None,
+                _host("ad", "ad", "ad", "win-2019"),
+                None,
+                id="none_when_not_configured",
+            ),
+            pytest.param(
+                {"win-2019": WIN_2019_USER_DATA},
+                _host("server", "master", "ipaserver", "rhel-8.5"),
+                None,
+                id="none_for_linux_host",
+            ),
+        ],
+    )
+    async def test_user_data_requirement(
+        self, config_user_data, meta_host, expected_user_data
+    ):
+        """Test user_data is correctly resolved in host requirements."""
+        transformer = await self._create_transformer(user_data=config_user_data)
+        req = transformer.create_host_requirement(meta_host)
+        err = (
+            f"user_data mismatch: {repr(req.get('user_data'))}"
+            f" != {repr(expected_user_data)}"
+        )
+        assert req.get("user_data") == expected_user_data, err
+
+    @pytest.mark.asyncio
+    async def test_user_data_for_multiple_windows_os(self):
+        """Test user_data is resolved correctly per OS when multiple are configured."""
+        transformer = await self._create_transformer(
+            user_data={
+                "win-2019": WIN_2019_USER_DATA,
+                "win-2022": WIN_2022_USER_DATA,
+            }
+        )
+        win19_req = transformer.create_host_requirement(
+            _host("ad", "ad", "ad", "win-2019")
+        )
+        win22_req = transformer.create_host_requirement(
+            _host("ad2", "ad", "ad", "win-2022")
+        )
+        assert win19_req.get("user_data") == WIN_2019_USER_DATA
+        assert win22_req.get("user_data") == WIN_2022_USER_DATA
+
+    @pytest.mark.asyncio
+    async def test_other_fields_unaffected_by_user_data(self):
+        """Test that adding user_data doesn't affect other requirement fields."""
+        transformer = await self._create_transformer(
+            user_data={"win-2019": WIN_2019_USER_DATA}
+        )
+        req = transformer.create_host_requirement(_host("ad", "ad", "ad", "win-2019"))
+        assert req["name"] == f"ad.{DOMAIN}"
+        assert req["os"] == "win-2019"
+        assert req["group"] == "ad"
+        assert req["image"] == "ami-win-2019"
+        assert req["flavor"] == "t2.medium"
+        assert req["security_group_ids"] == ["sg-something"]
+        assert req["user_data"] == WIN_2019_USER_DATA


### PR DESCRIPTION
Allow passing per-OS user_data from provisioning config to ec2.create_instances(). This enables boot-time instance configuration (e.g. enabling OpenSSH on Windows) without requiring custom AMIs.

in provisioning-config.yaml, user have to define user_data var and provide the set of commands it needs to execute on aws provisioned host like:
```
aws:
    images:
        win-2025: <image-id>
        win-2022: <image-id>

    flavors:
        default: t3.medium
        ...

    user_data:
        win-2025: |
            <powershell>
            # Set Administrator password (matches ad_admin_password in mhcfg)
            net user Administrator Secret123

            Restart-Service sshd
            </powershell>
        win-2022: |
            <powershell>
            # some commands
            </powershell>

    users:
        win-2025: Administrator
        win-2022: Administrator
```