### PR TITLE
fix: Pin setuptools<82 to restore pkg_resources for beaker-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=40.0.0,<82.0.0
 beaker-client>=29.2
 botocore>=1.14.17
 boto3>=1.11.17


### PR DESCRIPTION
setuptools 82.0.0 removed pkg_resources, which beaker-client imports at module level. This broke test collection for beaker-related tests.