### PR TITLE
feat: configure root EBS volume size via disksize(aws)

### DIFF
--- a/src/mrack/data/provisioning-config.yaml
+++ b/src/mrack/data/provisioning-config.yaml
@@ -63,9 +63,10 @@ aws:  # aws provider config
         win-2022-latest:  # find latest AMI via AWS SSM parameter
             ssm: /aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base
 
-    flavors:
-        # list of available flavours to ask from provider  for vm specs
-        default: t2.nano  # e.g. this is 1vcpus 0.5GB ram
+    # Deprecated: prefer aws.groups for flavor/disksize (groups take precedence).
+    # aws.flavors remains supported for backwards compatibility.
+    # flavors:
+    #     default: t2.nano  # e.g. this is 1vcpus 0.5GB ram
 
     keypair: mrack  # this name points to uploaded and available in aws ec2 key configuration
     security_group: sg-0ad1bab3a850e70fc  # setup the system firewall using one of existing sec groups
@@ -84,6 +85,17 @@ aws:  # aws provider config
         mrack: "True"
         persistent: "False"
     delete_volume_on_termination: True # instance volume is deleted on termination, default: True
+    # Per-group instance type and root volume (takes precedence over options)
+    options:
+        flavor: t2.nano  # default instance type
+        disksize: 10  # default root EBS volume size in GiB
+    groups:
+        client:
+            flavor: t3.micro
+            disksize: 20
+        ipaserver:
+            flavor: t3.medium
+            disksize: 40
     spot: True  # request spot EC2 instances, default: False
     resolve_host: False  # resolve hostname from IP on output generation, default: True
 

--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -374,6 +374,7 @@ class AWSProvider(Provider):
         specs = deepcopy(req)  # work with own copy, do not modify the input
 
         del_vol = specs.get("delete_volume_on_termination", True)
+        disksize = specs.get("disksize")
 
         name = req.get("name")
         # creating unique name for instance (visible in aws ec2 WebUI)
@@ -394,6 +395,13 @@ class AWSProvider(Provider):
 
         logger.debug(f"{log_msg_start} Tagging instance with: {object2json(taglist)}")
 
+        ebs = {"DeleteOnTermination": del_vol}
+        if disksize is not None:
+            ebs["VolumeSize"] = disksize
+            logger.info(
+                f"{log_msg_start} Root EBS volume size: {ebs['VolumeSize']} GiB"
+            )
+
         request = {
             "ImageId": self.get_image(specs).image_id,
             "MinCount": 1,
@@ -404,9 +412,7 @@ class AWSProvider(Provider):
             "BlockDeviceMappings": [
                 {
                     "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": del_vol,
-                    },
+                    "Ebs": ebs,
                 },
             ],
             "TagSpecifications": [{"ResourceType": "instance", "Tags": taglist}],

--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -25,7 +25,6 @@ class AWSTransformer(Transformer):
 
     _config_key = CONFIG_KEY
     _required_config_attrs = [
-        "flavors",
         "images",
         "credentials_file",
         "keypair",
@@ -95,6 +94,20 @@ class AWSTransformer(Transformer):
         super().validate_host(host)
         self.validate_ownership_and_lifetime(host)
 
+    def _get_host_option(self, host, name):
+        """Resolve host option from metadata, aws.groups, or aws.options."""
+        default_options = self.config.get("options", {})
+        group_options = self.config.get("groups", {}).get(host["group"], {})
+        val = host.get(name) or group_options.get(name) or default_options.get(name)
+
+        if val is None and name == "flavor" and self.config.get("flavors"):
+            val = super()._get_flavor(host)
+
+        if name == "disksize" and val is not None:
+            val = int(val)
+
+        return val
+
     def create_host_requirement(self, host):
         """Create single input for AWS provisioner."""
         del_vol = self._find_value(
@@ -104,7 +117,6 @@ class AWSTransformer(Transformer):
             "name": host["name"],
             "os": host["os"],
             "group": host["group"],
-            "flavor": self._get_flavor(host),
             "image": self._get_image(host),
             "security_group_ids": self._get_security_groups(),
             "spot": self._find_value(host, "spot", None, None),
@@ -112,6 +124,12 @@ class AWSTransformer(Transformer):
             "subnet_ids": self._find_subnet_ids(host),
             "user_data": self._find_value(host, "user_data", "user_data", host["os"]),
         }
+
+        for option in [
+            "flavor",
+            "disksize",
+        ]:
+            req[option] = self._get_host_option(host, option)
 
         req = self.update_metadata_for_owner_lifetime(req)
         return req

--- a/tests/unit/test_aws_transformer.py
+++ b/tests/unit/test_aws_transformer.py
@@ -199,6 +199,58 @@ class TestAWSTransformerUserData:
         assert win22_req.get("user_data") == WIN_2022_USER_DATA
 
     @pytest.mark.asyncio
+    async def test_disksize_from_group_options(self):
+        """Root volume size is resolved from aws.groups and aws.options."""
+        config = _aws_provisioning_config()
+        config["aws"]["options"] = {"disksize": 10}
+        config["aws"]["groups"] = {
+            "ipaclient": {"flavor": "t3.micro", "disksize": 20},
+            "ipaserver": {"flavor": "t3.medium", "disksize": 40},
+        }
+        providers.register(AWS, AWSProvider)
+        transformer = MockedAWSTransformer()
+        hosts = [
+            _host("client", "client", "ipaclient", "rhel-8.5"),
+            _host("server", "master", "ipaserver", "rhel-8.5"),
+        ]
+        metadata = {"domains": [{"name": DOMAIN, "type": "mixed", "hosts": hosts}]}
+        await transformer.init(config, metadata)
+
+        client_req = transformer.create_host_requirement(hosts[0])
+        server_req = transformer.create_host_requirement(hosts[1])
+        assert client_req["disksize"] == 20
+        assert server_req["disksize"] == 40
+        assert client_req["flavor"] == "t3.micro"
+        assert server_req["flavor"] == "t3.medium"
+
+    @pytest.mark.asyncio
+    async def test_disksize_from_default_options(self):
+        """Root volume size falls back to aws.options when group is undefined."""
+        config = _aws_provisioning_config()
+        config["aws"]["options"] = {"disksize": 15}
+        providers.register(AWS, AWSProvider)
+        transformer = MockedAWSTransformer()
+        host = _host("client", "client", "ipaclient", "rhel-8.5")
+        metadata = {"domains": [{"name": DOMAIN, "type": "mixed", "hosts": [host]}]}
+        await transformer.init(config, metadata)
+        req = transformer.create_host_requirement(host)
+        assert req["disksize"] == 15
+
+    @pytest.mark.asyncio
+    async def test_disksize_host_metadata_overrides_group(self):
+        """Host-level disksize in metadata overrides group defaults."""
+        config = _aws_provisioning_config()
+        config["aws"]["groups"] = {"ipaclient": {"disksize": 20}}
+        providers.register(AWS, AWSProvider)
+        transformer = MockedAWSTransformer()
+        host = _host("client", "client", "ipaclient", "rhel-8.5")
+        host["disksize"] = 30
+        metadata = {"domains": [{"name": DOMAIN, "type": "mixed", "hosts": [host]}]}
+        await transformer.init(config, metadata)
+        req = transformer.create_host_requirement(host)
+        assert req["disksize"] == 30
+
+    @pytest.mark.asyncio
     async def test_other_fields_unaffected_by_user_data(self):
         """Test that adding user_data doesn't affect other requirement fields."""
         transformer = await self._create_transformer(


### PR DESCRIPTION
EC2 instances previously inherited only the AMI snapshot size for the root volume, which is often too small for CI prep (e.g. client hosts running out of disk during Ansible runs).
Resolve disksize from host metadata, aws.groups, or aws.options and pass VolumeSize in BlockDeviceMappings when launching instances. Document defaults in the sample provisioning config and add unit tests.